### PR TITLE
Code review comments

### DIFF
--- a/lib/daru/accessors/nmatrix_wrapper.rb
+++ b/lib/daru/accessors/nmatrix_wrapper.rb
@@ -10,6 +10,7 @@ module Daru
       end
 
       def map!(&block)
+        #Not sure why you can't just use map! on a NMatrix slice?
         @data = NMatrix.new [@size*2], map(&block).to_a, dtype: nm_dtype
         self
       end
@@ -21,19 +22,31 @@ module Daru
       attr_reader :size, :data, :nm_dtype
       
       def initialize vector, context, nm_dtype=:int32
+        #Check that vector is correct shape and type.
+        #
+        #It would be really nice if this worked with nx1 matrices, since
+        #that's what NVector produces. I think this would just require a call
+        #to reshape. Right now it only works with 1xn
+        #matrices and flat 1D NMatrix's.
         @size = vector.size
+        #It's too bad NMatrix doesn't have resize method.
         @data = NMatrix.new [@size*2], vector.to_a, dtype: nm_dtype
         @context = context
         @nm_dtype = @data.dtype
         # init with twice the storage for reducing the need to resize
       end
 
+      #Shouldn't this take just a single integer argument?
       def [] *index
         return @data[*index] if index[0] < @size
         nil
       end
  
       def []= index, value
+        #Do you want to allow the case where index > @size? It doesn't seem like
+        #this is handled properly?
+
+        #what if index > @size*2?
         resize     if index >= @data.size
         @size += 1 if index == @size
         
@@ -42,6 +55,8 @@ module Daru
       end 
  
       def == other
+        #depending on the purpose of this method, maybe you only need to check
+        #if the first @size elements are the same.
         @data == other and @size == other.size
       end
  
@@ -60,6 +75,7 @@ module Daru
         resize if @size >= @data.size
         self[@size] = element
 
+        #@size is already incremented in #[]=
         @size += 1
       end
  
@@ -74,6 +90,7 @@ module Daru
       def resize size = @size*2
         raise ArgumentError, "Size must be greater than current size" if size < @size
 
+        #include dtype argument?
         @data = NMatrix.new [size], @data.to_a
       end
 
@@ -90,6 +107,8 @@ module Daru
       end
 
       def max
+        #Not using a slice here will get you in trouble if you use #delete_at.
+        #Also, I think it might be faster to use a slice.
         @data.max
       end
 

--- a/lib/daru/core/group_by.rb
+++ b/lib/daru/core/group_by.rb
@@ -84,9 +84,12 @@ module Daru
 
       # Returns one of the selected groups as a DataFrame.
       def get_group group
+        #raise a helpful error if group doesn't exist
         indexes   = @groups[group]
         elements  = []
 
+        #do you do it like this because iterating over vectors is faster than
+        #iterating over rows? Otherwise, it would be clearer the other way.
         @context.each_vector do |vector|
           elements << vector.to_a
         end

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -1187,7 +1187,9 @@ module Daru
     #   # ["foo", "one", 3]=>[6],
     #   # ["foo", "three", 8]=>[7],
     #   # ["foo", "two", 3]=>[2, 4]}
+    #why not *vectors?
     def group_by vectors
+      #validate arguments more?
       vectors = [vectors] if vectors.is_a?(Symbol)
       vectors.each { |v| raise(ArgumentError, "Vector #{v} does not exist") unless
         has_vector?(v) }
@@ -1323,6 +1325,13 @@ module Daru
     #   # 3          4          1 
     #   df.sort([:a], by: { a: lambda { |a,b| a.abs <=> b.abs } })  
     def sort! vector_order, opts={}
+      #I don't really have any brilliant ideas what to do here. It sounds
+      #like what you want is a fast sort function that doesn't just let you define
+      #the comparison function, but also the swap function, which sounds not
+      #impossible. Have you tried the approach of transforming the whole
+      #dataframe into an array of rows, then using the Array#sort! with
+      #a custom comparison, then recreating the whole dataframe? It would be
+      #interesting to see how this performs compared to your implementation.
       raise ArgumentError, "Required atleast one vector name" if vector_order.size < 1
       opts = {
         ascending: true,


### PR DESCRIPTION
My comments on code are in the patch, sorry I didn't look at that much of it.

Some general comments:

I couldn't find an easy way to test daru as I edited the source. What I had to do was run `pry -I./lib` and then `require 'daru'`. It would be nice if there were a more convenient way to do this. For example, nmatrix has a `rake pry` task, and some projects have a `bin/console` script, that just opens irb/pry with the appropriate libraries loaded. It also would be nice to have a rake task for installing the gem.

I think using `and` and `or` instead of `&&` and `||` is pretty frowned upon in Ruby. [One explanation of why](http://stackoverflow.com/questions/2083112/difference-between-or-and-in-ruby).

Is there a way to save plots as images programatically? Without iPython? I may have missed it, but I couldn't find it. I realize that this is a limitation of your plotting library, and not daru, so I'm definitely not asking you to implement it, but this is really an essential feature. I had a difficult time installing iruby/ipython, so it would also be nice to be able to do it without them.

I took a quick look at your query code. I would really, really appreciate it if you developed something that was more powerful and that was just powered by plain ruby. Let me try to give you an example. In particle physics, we use a library called [ROOT](https://root.cern.ch/drupal/), where the essential data storage abstraction is a class called [TTree](https://root.cern.ch/root/html/TTree.html), which is roughly equivalent to a dataframe. Say we have a TTree with three "columns": position_x, position_y, momentum. There is a really handy method `TTree::Draw()`, so that if we want to plot a histogram of momentum, selecting only events (rows) with certain values of position we can just say `tree->Draw("momentum", "position_x*position_x + position_y*position_y < 1")`. `TTree::Draw()` is great and we use it all the time, but for any type of refined analysis it becomes useless because the syntax used in the selection string is not powerful enough. For more complex selection criteria (and we always want more complex selection criteria), we have to use a totally different method which is pretty unwieldy. The reason for this is that we're working in C++ and we can't just pass around arbitrary C++ code, instead we just pass a small string that approximates a very tiny subset of C, which is very limiting. But we don't have that limitation in Ruby. I think it would be really great to have a selection function that took a block which could evaluate an arbitrarily complex function for each row and then return true or false. That way we wouldn't have to learn any new syntax, and you wouldn't have to worry about implementing query code for every possible use case. I haven't really deeply thought this through, so maybe this wouldn't work as well I think. Or maybe it's already possible to do this.