### PR TITLE
faster algorithm for inner join

### DIFF
--- a/daru.gemspec
+++ b/daru.gemspec
@@ -51,7 +51,6 @@ EOF
 
   spec.add_runtime_dependency 'reportbuilder', '~> 1.4'
   spec.add_runtime_dependency 'spreadsheet', '~> 1.0.3'
-  spec.add_runtime_dependency 'bloomfilter-rb', '~> 2.1'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake'
@@ -64,4 +63,5 @@ EOF
   spec.add_development_dependency 'nmatrix', '~> 0.1.0'
   spec.add_development_dependency 'distribution', '~> 0.7'
   spec.add_development_dependency 'rb-gsl', '~>1.16'
+  spec.add_development_dependency 'bloomfilter-rb', '~> 2.1'
 end

--- a/daru.gemspec
+++ b/daru.gemspec
@@ -51,6 +51,7 @@ EOF
 
   spec.add_runtime_dependency 'reportbuilder', '~> 1.4'
   spec.add_runtime_dependency 'spreadsheet', '~> 1.0.3'
+  spec.add_runtime_dependency 'bloomfilter-rb', '~> 2.1'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake'

--- a/lib/daru.rb
+++ b/lib/daru.rb
@@ -38,8 +38,9 @@ module Daru
     attr_accessor :lazy_update
     
     def create_has_library(library)
-      define_singleton_method("has_#{library}?") do
-        cv = "@@#{library}"
+      lib_underscore = library.to_s.gsub(/-/, '_')
+      define_singleton_method("has_#{lib_underscore}?") do
+        cv = "@@#{lib_underscore}"
         unless class_variable_defined? cv
           begin
             require library.to_s
@@ -56,6 +57,7 @@ module Daru
   create_has_library :gsl
   create_has_library :nmatrix
   create_has_library :nyaplot
+  create_has_library :'bloomfilter-rb'
 end
 
 autoload :Spreadsheet, 'spreadsheet'
@@ -64,7 +66,6 @@ autoload :CSV, 'csv'
 require 'matrix'
 require 'securerandom'
 require 'reportbuilder'
-require 'bloomfilter-rb'
 
 require 'daru/version.rb'
 require 'daru/index.rb'

--- a/lib/daru.rb
+++ b/lib/daru.rb
@@ -64,6 +64,7 @@ autoload :CSV, 'csv'
 require 'matrix'
 require 'securerandom'
 require 'reportbuilder'
+require 'bloomfilter-rb'
 
 require 'daru/version.rb'
 require 'daru/index.rb'

--- a/lib/daru/core/merge.rb
+++ b/lib/daru/core/merge.rb
@@ -42,7 +42,26 @@ module Daru
           return col_names, values
         end
 
-        def inner_join df1, df2, on
+        def inner_join df1, df2, df_hash1, df_hash2, on
+          joined_hash = {}
+          ((df_hash1.keys - on) | on | (df_hash2.keys - on)).each do |k|
+            joined_hash[k] = []
+          end
+
+          (0...df1.size).each do |id1|
+            (0...df2.size).each do |id2|
+              if on.all? { |n| df_hash1[n][id1] == df_hash2[n][id2] }
+                joined_hash.each do |k,v|
+                  v << (df_hash1.has_key?(k) ? df_hash1[k][id1] : df_hash2[k][id2])
+                end
+              end
+            end
+          end
+
+          Daru::DataFrame.new(joined_hash, order: joined_hash.keys)
+        end
+
+        def bf_inner_join df1, df2, on
           col_names1, table1 = arrayify df1
           col_names2, table2 = arrayify df2
 
@@ -188,7 +207,11 @@ module Daru
 
           case opts[:how]
           when :inner
-            helper.inner_join df1, df2, on
+            if Daru.has_bloomfilter_rb?
+              helper.bf_inner_join df1, df2, on
+            else
+              helper.inner_join df1, df2, df_hash1, df_hash2, on
+            end
           when :outer
             helper.full_outer_join df1, df2, df_hash1, df_hash2, on
           when :left

--- a/lib/daru/core/merge.rb
+++ b/lib/daru/core/merge.rb
@@ -98,7 +98,7 @@ module Daru
             end
           end
             .reduce({}) {|h,pairs| pairs.each {|k,v| (h[k] ||= []) << v}; h}
-            .map{|ind1, inds2| inds2.flatten.flat_map{|ind2| [table1[ind1], table2[ind2]].flatten} if inds2.flatten.size > 0}
+            .flat_map{|ind1, inds2| inds2.flatten.map{|ind2| [table1[ind1], table2[ind2]].flatten} if inds2.flatten.size > 0}
 
           joined_cols = [col_names1, col_names2].flatten
           df = Daru::DataFrame.rows(joined_new.compact, order: joined_cols)

--- a/lib/daru/core/merge.rb
+++ b/lib/daru/core/merge.rb
@@ -33,24 +33,59 @@ module Daru
           hsh.each { |k,v| hsh[k] = v.to_a }
           hsh
         end
+        
+        def arrayify df
+          arr = df.to_a
+          col_names = arr[0][0].keys
+          values = arr[0].map{|h| h.values}
 
-        def inner_join df1, df2, df_hash1, df_hash2, on
-          joined_hash = {}
-          ((df_hash1.keys - on) | on | (df_hash2.keys - on)).each do |k|
-            joined_hash[k] = []
-          end
+          return col_names, values
+        end
 
-          (0...df1.size).each do |id1|
-            (0...df2.size).each do |id2|
-              if on.all? { |n| df_hash1[n][id1] == df_hash2[n][id2] }
-                joined_hash.each do |k,v|
-                  v << (df_hash1.has_key?(k) ? df_hash1[k][id1] : df_hash2[k][id2])
-                end
-              end
+        def inner_join df1, df2, on
+          col_names1, table1 = arrayify df1
+          col_names2, table2 = arrayify df2
+
+          #resolve duplicates
+          indicies1 = on.map{|i| col_names1.index(i)}
+          indicies2 = on.map{|i| col_names2.index(i)}
+          col_names2.map! do |name| 
+            if (col_names1.include?(name))
+              col_names1[col_names1.index(name)] = (name.to_s + "_1").to_sym unless on.include?(name)
+              (name.to_s + "_2").to_sym
+            else
+              name
             end
           end
 
-          Daru::DataFrame.new(joined_hash, order: joined_hash.keys)
+          #combine key columns to a single column value
+          on_cols1 = table1.flat_map{|x| indicies1.map{|i| x[i].to_s}.join("+")}
+          on_cols2 = table2.flat_map{|x| indicies2.map{|i| x[i].to_s}.join("+")}
+
+          #parameters for a BF with approx 0.1% false positives
+          m = on_cols2.size * 15
+          k = 11
+
+          bf = BloomFilter::Native.new({:size => m, :hashes => k, :bucket => 1})
+          on_cols2.each{|x| bf.insert(x)}
+
+          x_ind = -1
+          joined_new = on_cols1.map do |x|
+            x_ind+=1
+            if (bf.include?(x))
+              {x_ind => on_cols2.each_index.select{|y_ind| on_cols2[y_ind] == x}}
+            else
+              {x_ind => []}
+            end
+          end
+            .reduce({}) {|h,pairs| pairs.each {|k,v| (h[k] ||= []) << v}; h}
+            .map{|ind1, inds2| inds2.flatten.flat_map{|ind2| [table1[ind1], table2[ind2]].flatten} if inds2.flatten.size > 0}
+
+          joined_cols = [col_names1, col_names2].flatten
+          df = Daru::DataFrame.rows(joined_new.compact, order: joined_cols)
+          on.each{|x| df.delete_vector (x.to_s + "_2").to_sym}
+
+          df
         end
 
         def full_outer_join df1, df2, df_hash1, df_hash2, on
@@ -153,7 +188,7 @@ module Daru
 
           case opts[:how]
           when :inner
-            helper.inner_join df1, df2, df_hash1, df_hash2, on
+            helper.inner_join df1, df2, on
           when :outer
             helper.full_outer_join df1, df2, df_hash1, df_hash2, on
           when :left

--- a/lib/daru/version.rb
+++ b/lib/daru/version.rb
@@ -1,3 +1,3 @@
 module Daru
-  VERSION = "0.1.2"
+  VERSION = "0.1.1"
 end

--- a/lib/daru/version.rb
+++ b/lib/daru/version.rb
@@ -1,3 +1,3 @@
 module Daru
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/spec/core/merge_spec.rb
+++ b/spec/core/merge_spec.rb
@@ -11,6 +11,10 @@ describe Daru::DataFrame do
         :id => [1,2,3,4],
         :name => ['Rutabaga', 'Pirate', 'Darth Vader', 'Ninja']
       })
+      @right_many = Daru::DataFrame.new({
+        :id => [1,1,1,1],
+        :name => ['Rutabaga', 'Pirate', 'Darth Vader', 'Ninja']
+      })
     end
 
     it "performs an inner join of two dataframes" do
@@ -20,6 +24,15 @@ describe Daru::DataFrame do
         :id_2   => [2,4]
       }, order: [:id_1, :name, :id_2])
       expect(@left.join(@right, how: :inner, on: [:name])).to eq(answer)
+    end
+
+    it "performs an inner join of two dataframes that has one to many mapping" do
+      answer = Daru::DataFrame.new({
+        :id => [1,1,1,1],
+        :name_1 => ['Pirate', 'Pirate', 'Pirate', 'Pirate'],
+        :name_2 => ['Rutabaga', 'Pirate', 'Darth Vader', 'Ninja']
+      }, order: [:id, :name_1, :name_2])
+      expect(@left.join(@right_many, how: :inner, on: [:id])).to eq(answer)
     end
 
     it "performs a full outer join" do


### PR DESCRIPTION
Code used for benchmarking: https://gist.github.com/peterktung/63c3b6d87fe22cb85621

Results:
```
Before:
Rehearsal --------------------------------------------------------
full_inner:          413.590000   0.850000 414.440000 (415.140870)
sparse_inner:        386.930000   0.380000 387.310000 (387.571845)
--------------------------------------------- total: 801.750000sec

                           user     system      total        real
full_inner:          388.470000   0.370000 388.840000 (389.073046)
sparse_inner:        400.040000   0.460000 400.500000 (400.807328)

After:
Rehearsal --------------------------------------------------------
full_inner:           85.980000   0.130000  86.110000 ( 86.224135)
sparse_inner:         83.670000   0.070000  83.740000 ( 83.777885)
--------------------------------------------- total: 169.850000sec

                           user     system      total        real
full_inner:           87.270000   0.100000  87.370000 ( 87.423039)
sparse_inner:         85.260000   0.110000  85.370000 ( 85.442580)
```