### PR TITLE
faster filter_row implementation

### DIFF
--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -906,19 +906,19 @@ module Daru
     def filter_rows &block
       return to_enum(:filter_rows) unless block_given?
 
-      df = Daru::DataFrame.new({}, order: @vectors.to_a)
-      marked = []
+      values = to_a[0].map{|h| h.values}
+      index = @index.to_a
 
-      @index.each do |index|
-        keep_row = yield access_row(index)
-        marked << index if keep_row
+      arr_index = index.length - 1
+      index.reverse.each do |i|
+        keep_row = yield access_row(i)
+        unless keep_row
+          index.delete_at(i)
+          values.delete_at(i)
+        end
       end
 
-      marked.each do |idx|
-        df.row[idx] = self[idx, :row]
-      end
-
-      df
+      Daru::DataFrame.rows(values, {order: @vectors.to_a, index: index})
     end
 
     # Iterates over each vector and retains it in a new DataFrame if the block returns

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -909,7 +909,6 @@ module Daru
       values = to_a[0].map{|h| h.values}
       index = @index.to_a
 
-      arr_index = index.length - 1
       index.reverse.each do |i|
         keep_row = yield access_row(i)
         unless keep_row


### PR DESCRIPTION
Benchmark code here: https://gist.github.com/peterktung/f60f83d7ec9d6e84fe71
```
Before:
Rehearsal --------------------------------------------------------
filter_row:           98.750000   1.090000  99.840000 ( 99.890700)
---------------------------------------------- total: 99.840000sec

                           user     system      total        real
filter_row:           98.130000   1.120000  99.250000 ( 99.311869)

After:
Rehearsal --------------------------------------------------------
filter_row:            2.180000   0.010000   2.190000 (  2.192253)
----------------------------------------------- total: 2.190000sec

                           user     system      total        real
filter_row:            2.180000   0.010000   2.190000 (  2.187111)
```