### PR TITLE
Make reportbuilder an optional dependency

### DIFF
--- a/daru.gemspec
+++ b/daru.gemspec
@@ -49,7 +49,6 @@ Cheers!
 *************************************************************************
 EOF
 
-  spec.add_runtime_dependency 'reportbuilder', '~> 1.4'
   spec.add_runtime_dependency 'spreadsheet', '~> 1.0.3'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
@@ -60,6 +59,7 @@ EOF
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'awesome_print'
   spec.add_development_dependency 'nyaplot', '~> 0.1.5'
+  spec.add_development_dependency 'reportbuilder', '~> 1.4'
   spec.add_development_dependency 'nmatrix', '~> 0.1.0'
   spec.add_development_dependency 'distribution', '~> 0.7'
   spec.add_development_dependency 'rb-gsl', '~>1.16'

--- a/lib/daru.rb
+++ b/lib/daru.rb
@@ -58,6 +58,7 @@ module Daru
   create_has_library :nmatrix
   create_has_library :nyaplot
   create_has_library :'bloomfilter-rb'
+  create_has_library :reportbuilder
 end
 
 autoload :Spreadsheet, 'spreadsheet'
@@ -65,7 +66,6 @@ autoload :CSV, 'csv'
 
 require 'matrix'
 require 'securerandom'
-require 'reportbuilder'
 
 require 'daru/version.rb'
 require 'daru/index.rb'

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -12,6 +12,7 @@ module Daru
     include Daru::Maths::Arithmetic::DataFrame
     include Daru::Maths::Statistics::DataFrame
     include Daru::Plotting::DataFrame if Daru.has_nyaplot?
+    include Daru::ReportBuilder if Daru.has_reportbuilder?
 
     class << self
       # Load data from a CSV file. Specify an optional block to grab the CSV 
@@ -1360,11 +1361,6 @@ module Daru
 
       order = Index.new(nv)
       Daru::DataFrame.new(arry, clone: cln, order: order, index: @index)
-    end
-
-    # Generate a summary of this DataFrame with ReportBuilder.
-    def summary(method = :to_text)
-      ReportBuilder.new(no_title: true).add(self).send(method)
     end
 
     def report_building(b) # :nodoc: #

--- a/lib/daru/report_builder.rb
+++ b/lib/daru/report_builder.rb
@@ -1,0 +1,8 @@
+module Daru
+  module ReportBuilder
+    # Generate a summary of this object with ReportBuilder.
+    def summary(method = :to_text)
+      ReportBuilder.new(no_title: true).add(self).send(method)
+    end
+  end
+end if Daru.has_reportbuilder?

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -13,6 +13,7 @@ module Daru
     include Daru::Maths::Arithmetic::Vector
     include Daru::Maths::Statistics::Vector
     include Daru::Plotting::Vector if Daru.has_nyaplot?
+    include Daru::ReportBuilder if Daru.has_reportbuilder?
 
     def each(&block)
       return to_enum(:each) unless block_given?
@@ -896,11 +897,6 @@ module Daru
 
     def to_s
       to_html
-    end
-
-    # Create a summary of the Vector using Report Builder.
-    def summary(method = :to_text)
-      ReportBuilder.new(no_title: true).add(self).send(method)
     end
 
     def report_building b


### PR DESCRIPTION
The `reportbuilder` gem brings in amongst other things the entirety of prawn.
Technically this is a breaking change, but if that's a problem I can add a warning when the previous method is called