### PR TITLE
Fix IO.from_sql

### DIFF
--- a/daru.gemspec
+++ b/daru.gemspec
@@ -60,8 +60,10 @@ EOF
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'awesome_print'
   spec.add_development_dependency 'nyaplot', '~> 0.1.5'
-  spec.add_development_dependency 'nmatrix', '~> 0.1.0'
+  spec.add_development_dependency 'nmatrix', '~> 0.2.0'
   spec.add_development_dependency 'distribution', '~> 0.7'
   spec.add_development_dependency 'rb-gsl', '~>1.16'
   spec.add_development_dependency 'bloomfilter-rb', '~> 2.1'
+  spec.add_development_dependency 'dbd-sqlite3'
+  spec.add_development_dependency 'dbi'
 end

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -63,6 +63,11 @@ module Daru
 
       # Read a database query and returns a Dataset
       #
+      # @param dbh [DBI::DatabaseHandle] A DBI connection to be used to run the query
+      # @param query [String] The query to be executed
+      #
+      # @return A dataframe containing the data resulting from the query
+      #
       # USE:
       #
       #  dbh = DBI.connect("DBI:Mysql:database:localhost", "user", "password")

--- a/spec/io/io_spec.rb
+++ b/spec/io/io_spec.rb
@@ -85,8 +85,26 @@ describe Daru::IO do
     end
 
     context ".from_sql" do
+
+      let(:db) { DBI.connect("DBI:SQLite3:daru_test") }
+
+      subject { Daru::DataFrame.from_sql(db, "select * from accounts") }
+
+      before do
+        require "dbi"
+        db.do "create table accounts(id integer, name varchar)"
+        db.do "insert into accounts values(1, 'Homer')"
+        db.do "insert into accounts values(2, 'Marge')"
+      end
+
+      after { FileUtils.rm("daru_test") }
+
       it "loads data from an SQL database" do
-        # TODO: write these tests
+        accounts = subject
+        expect(accounts.class).to eq Daru::DataFrame
+        expect(accounts.nrows).to eq 2
+        expect(accounts.row[0][:id]).to eq 1
+        expect(accounts.row[0][:name]).to eq "Homer"
       end
     end
 


### PR DESCRIPTION
The IO.from_sql method was using the dbi column_info to create the vectors of the data frame. This is resulting in an error:

```RuntimeError: can't add a new key into hash during iteration```

I've updated it to use the column_names method instead which does not result in updating the object you're iterating through.