### PR TITLE
Add ActiveRecord support

### DIFF
--- a/daru.gemspec
+++ b/daru.gemspec
@@ -66,4 +66,6 @@ EOF
   spec.add_development_dependency 'bloomfilter-rb', '~> 2.1'
   spec.add_development_dependency 'dbd-sqlite3'
   spec.add_development_dependency 'dbi'
+  spec.add_development_dependency 'activerecord', '~> 4.0'
+  spec.add_development_dependency 'sqlite3'
 end

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -76,6 +76,26 @@ module Daru
         Daru::IO.from_sql dbh, query
       end
 
+      # Read a dataframe from AR::Relation
+      #
+      # @param relation [ActiveRecord::Relation] An AR::Relation object from which data is loaded
+      # @params fields [Array] Field names to be loaded (optional)
+      #
+      # @return A dataframe containing the data loaded from the relation
+      #
+      # USE:
+      #
+      #   # When Post model is defined as:
+      #   class Post < ActiveRecord::Base
+      #     scope :active, -> { where.not(published_at: nil) }
+      #   end
+      #
+      #   # You can load active posts into a dataframe by:
+      #   Daru::DataFrame.from_activerecord(Post.active, :title, :published_at)
+      def from_activerecord relation, *fields
+        Daru::IO.from_activerecord relation, *fields
+      end
+
       # Read the database from a plaintext file. For this method to work,
       # the data should be present in a plain text file in columns. See
       # spec/fixtures/bank2.dat for an example.

--- a/lib/daru/io/sql_data_source.rb
+++ b/lib/daru/io/sql_data_source.rb
@@ -1,0 +1,116 @@
+module Daru
+  module IO
+    class SqlDataSource
+      # Private adapter class for DBI::DatabaseHandle
+      # @private
+      class DbiAdapter
+        def initialize(dbh, query)
+          @dbh = dbh
+          @query = query
+        end
+
+        def each_column_name(&block)
+          result.column_names.each do |column_name|
+            block.(column_name.to_sym)
+          end
+        end
+
+        def each_row(&block)
+          result.fetch do |row|
+            block.(row.to_a)
+          end
+        end
+
+        private
+
+        def result
+          @result ||= @dbh.execute(@query)
+        end
+      end
+
+      # Private adapter class for connections of ActiveRecord
+      # @private
+      class ActiveRecordConnectionAdapter
+        def initialize(conn, query)
+          @conn = conn
+          @query = query
+        end
+
+        def each_column_name(&block)
+          result.columns.each do |column_name|
+            block.(column_name.to_sym)
+          end
+        end
+
+        def each_row(&block)
+          result.each do |row|
+            block.(row.values)
+          end
+        end
+
+        private
+
+        def result
+          @result ||= @conn.exec_query(@query)
+        end
+      end
+
+      private_constant :DbiAdapter
+      private_constant :ActiveRecordConnectionAdapter
+
+      def self.make_dataframe(db, query)
+        self.new(db, query).make_dataframe
+      end
+
+      def initialize(db, query)
+        @adapter = init_adapter(db, query)
+      end
+
+      def make_dataframe
+        vectors = {}
+        fields = []
+        @adapter.each_column_name do |column_name|
+          vectors[column_name] = Daru::Vector.new([])
+          vectors[column_name].rename column_name
+          fields.push column_name
+        end
+
+        df = Daru::DataFrame.new(vectors, order: fields)
+        @adapter.each_row do |row|
+          df.add_row(row)
+        end
+
+        df.update
+
+        df
+      end
+
+      private
+
+      def init_adapter(db, query)
+        begin
+          query = query.to_str
+        rescue
+          raise ArgumentError, 'query must be a string'
+        end
+
+        case
+        when check_dbi(db)
+          DbiAdapter.new(db, query)
+        when check_active_record_connection(db)
+          ActiveRecordConnectionAdapter.new(db, query)
+        else
+          raise ArgumentError, 'unknown database type'
+        end
+      end
+
+      def check_dbi(obj)
+        DBI::DatabaseHandle === obj rescue false
+      end
+
+      def check_active_record_connection(obj)
+        ActiveRecord::ConnectionAdapters::AbstractAdapter === obj rescue false
+      end
+    end
+  end
+end

--- a/spec/io/sql_data_source_spec.rb
+++ b/spec/io/sql_data_source_spec.rb
@@ -5,25 +5,7 @@ require 'dbi'
 require 'active_record'
 
 RSpec.describe Daru::IO::SqlDataSource do
-  let(:db_name) do
-    'daru_test'
-  end
-
-  before do
-    # just in case
-    FileUtils.rm(db_name) if File.file?(db_name)
-
-    SQLite3::Database.new(db_name).tap do |db|
-      db.execute "create table accounts(id integer, name varchar)"
-      db.execute "insert into accounts values(1, 'Homer')"
-      db.execute "insert into accounts values(2, 'Marge')"
-    end
-  end
-
-  after do
-    FileUtils.rm(db_name)
-  end
-
+  include_context 'with accounts table in sqlite3 database'
   let(:dbi_handle) do
     DBI.connect("DBI:SQLite3:#{db_name}")
   end

--- a/spec/io/sql_data_source_spec.rb
+++ b/spec/io/sql_data_source_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+require 'daru/io/sql_data_source'
+require 'sqlite3'
+require 'dbi'
+require 'active_record'
+
+RSpec.describe Daru::IO::SqlDataSource do
+  let(:db_name) do
+    'daru_test'
+  end
+
+  before do
+    # just in case
+    FileUtils.rm(db_name) if File.file?(db_name)
+
+    SQLite3::Database.new(db_name).tap do |db|
+      db.execute "create table accounts(id integer, name varchar)"
+      db.execute "insert into accounts values(1, 'Homer')"
+      db.execute "insert into accounts values(2, 'Marge')"
+    end
+  end
+
+  after do
+    FileUtils.rm(db_name)
+  end
+
+  let(:dbi_handle) do
+    DBI.connect("DBI:SQLite3:#{db_name}")
+  end
+
+  let(:active_record_connection) do
+    ActiveRecord::Base.establish_connection("sqlite3:#{db_name}")
+    ActiveRecord::Base.connection
+  end
+
+  let(:query) do
+    'select * from accounts'
+  end
+
+  describe '.make_dataframe' do
+    context 'with DBI::DatabaseHandle' do
+      it 'returns a dataframe' do
+        result = Daru::IO::SqlDataSource.make_dataframe(dbi_handle, query)
+        expect(result).to be_a(Daru::DataFrame)
+        expect(result.nrows).to eq(2)
+        expect(result.row[0][:id]).to eq(1)
+        expect(result.row[0][:name]).to eq('Homer')
+      end
+
+      context 'with an object not a string as a query' do
+        it 'raises ArgumentError' do
+          expect {
+            Daru::IO::SqlDataSource.make_dataframe(dbi_handle, Object.new)
+          }.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    context 'with DBI::DatabaseHandle' do
+      it 'returns a dataframe' do
+        result = Daru::IO::SqlDataSource.make_dataframe(active_record_connection, query)
+        expect(result).to be_a(Daru::DataFrame)
+        expect(result.nrows).to eq(2)
+        expect(result.row[0][:id]).to eq(1)
+        expect(result.row[0][:name]).to eq('Homer')
+      end
+
+      context 'with an object not a string as a query' do
+        it 'raises ArgumentError' do
+          expect {
+            Daru::IO::SqlDataSource.make_dataframe(active_record_connection, Object.new)
+          }.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    context 'with an object not a database connection' do
+      it 'raises ArgumentError' do
+        expect {
+          Daru::IO::SqlDataSource.make_dataframe(Object.new, query)
+        }.to raise_error(ArgumentError)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,3 +41,5 @@ def expect_correct_df_in_delta df1, df2, delta
     expect_correct_vector_in_delta vector, df2[i], delta
   end
 end
+
+Dir[File.expand_path('../support/**/*.rb', __FILE__)].each {|f| require f }

--- a/spec/support/database_helper.rb
+++ b/spec/support/database_helper.rb
@@ -1,0 +1,27 @@
+require 'sqlite3'
+require 'dbi'
+require 'active_record'
+
+module Daru::RSpec
+  class Account < ActiveRecord::Base
+    self.table_name = 'accounts'
+  end
+end
+
+shared_context 'with accounts table in sqlite3 database' do
+  let(:db_name) do
+    'daru_test'
+  end
+
+  before do
+    SQLite3::Database.new(db_name).tap do |db|
+      db.execute "create table accounts(id integer, name varchar, age integer, primary key(id))"
+      db.execute "insert into accounts values(1, 'Homer', 20)"
+      db.execute "insert into accounts values(2, 'Marge', 30)"
+    end
+  end
+
+  after do
+    FileUtils.rm(db_name)
+  end
+end

--- a/spec/support/database_helper.rb
+++ b/spec/support/database_helper.rb
@@ -14,6 +14,9 @@ shared_context 'with accounts table in sqlite3 database' do
   end
 
   before do
+    # just in case
+    FileUtils.rm(db_name) if File.file?(db_name)
+
     SQLite3::Database.new(db_name).tap do |db|
       db.execute "create table accounts(id integer, name varchar, age integer, primary key(id))"
       db.execute "insert into accounts values(1, 'Homer', 20)"


### PR DESCRIPTION
This pull request makes daru to support ActiveRecord both relation and connection.

The following things are done in this:
- Modify Daru::IO.from_sql to support database connections of AR.
- Add Daru::DataFrame.from_activerecord to load data from AR::Relation.
