### PR TITLE
FIX - DataFrame dup now duplicates the underlying vector arrays.

### DIFF
--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -14,30 +14,30 @@ module Daru
     include Daru::Plotting::DataFrame if Daru.has_nyaplot?
 
     class << self
-      # Load data from a CSV file. Specify an optional block to grab the CSV 
-      # object and pre-condition it (for example use the `convert` or 
+      # Load data from a CSV file. Specify an optional block to grab the CSV
+      # object and pre-condition it (for example use the `convert` or
       # `header_convert` methods).
-      # 
+      #
       # == Arguments
-      # 
+      #
       # * path - Path of the file to load specified as a String.
-      # 
+      #
       # == Options
-      # 
+      #
       # Accepts the same options as the Daru::DataFrame constructor and CSV.open()
       # and uses those to eventually construct the resulting DataFrame.
       #
       # == Verbose Description
       #
-      # You can specify all the options to the `.from_csv` function that you 
+      # You can specify all the options to the `.from_csv` function that you
       # do to the Ruby `CSV.read()` function, since this is what is used internally.
       #
-      # For example, if the columns in your CSV file are separated by something 
-      # other that commas, you can use the `:col_sep` option. If you want to 
-      # convert numeric values to numbers and not keep them as strings, you can 
+      # For example, if the columns in your CSV file are separated by something
+      # other that commas, you can use the `:col_sep` option. If you want to
+      # convert numeric values to numbers and not keep them as strings, you can
       # use the `:converters` option and set it to `:numeric`.
       #
-      # The `.from_csv` function uses the following defaults for reading CSV files 
+      # The `.from_csv` function uses the following defaults for reading CSV files
       # (that are passed into the `CSV.read()` function):
       #
       #   {
@@ -45,19 +45,19 @@ module Daru
       #     :converters        => :numeric
       #   }
       def from_csv path, opts={}, &block
-        Daru::IO.from_csv path, opts, &block      
+        Daru::IO.from_csv path, opts, &block
       end
 
       # Read data from an Excel file into a DataFrame.
-      # 
+      #
       # == Arguments
-      # 
+      #
       # * path - Path of the file to be read.
-      # 
+      #
       # == Options
-      # 
+      #
       # *:worksheet_id - ID of the worksheet that is to be read.
-      def from_excel path, opts={}, &block      
+      def from_excel path, opts={}, &block
         Daru::IO.from_excel path, opts, &block
       end
 
@@ -99,14 +99,14 @@ module Daru
       # Read the database from a plaintext file. For this method to work,
       # the data should be present in a plain text file in columns. See
       # spec/fixtures/bank2.dat for an example.
-      # 
+      #
       # == Arguments
-      # 
+      #
       # * path - Path of the file to be read.
       # * fields - Vector names of the resulting database.
-      # 
+      #
       # == Usage
-      # 
+      #
       #   df = Daru::DataFrame.from_plaintext 'spec/fixtures/bank2.dat', [:v1,:v2,:v3,:v4,:v5,:v6]
       def from_plaintext path, fields
         Daru::IO.from_plaintext path, fields
@@ -162,15 +162,15 @@ module Daru
       #
       # Useful to process outputs from databases
       def crosstab_by_assignation rows, columns, values
-        raise "Three vectors should be equal size" if 
+        raise "Three vectors should be equal size" if
           rows.size != columns.size or rows.size!=values.size
 
         cols_values = columns.factors
         cols_n      = cols_values.size
 
-        h_rows = rows.factors.inject({}) do |a,v| 
-          a[v] = cols_values.inject({}) do |a1,v1| 
-            a1[v1]=nil 
+        h_rows = rows.factors.inject({}) do |a,v|
+          a[v] = cols_values.inject({}) do |a1,v1|
+            a1[v1]=nil
             a1
           end
           a
@@ -211,38 +211,38 @@ module Daru
     # These objects are indexed by row and column by vectors and index Index objects.
     #
     # == Arguments
-    # 
+    #
     # * source - Source from the DataFrame is to be initialized. Can be a Hash
     # of names and vectors (array or Daru::Vector), an array of arrays or
     # array of Daru::Vectors.
-    # 
+    #
     # == Options
-    # 
-    # +:order+ - An *Array*/*Daru::Index*/*Daru::MultiIndex* containing the order in 
+    #
+    # +:order+ - An *Array*/*Daru::Index*/*Daru::MultiIndex* containing the order in
     # which Vectors should appear in the DataFrame.
-    # 
+    #
     # +:index+ - An *Array*/*Daru::Index*/*Daru::MultiIndex* containing the order
     # in which rows of the DataFrame will be named.
-    # 
+    #
     # +:name+  - A name for the DataFrame.
     #
     # +:clone+ - Specify as *true* or *false*. When set to false, and Vector
     # objects are passed for the source, the Vector objects will not duplicated
-    # when creating the DataFrame. Will have no effect if Array is passed in 
-    # the source, or if the passed Daru::Vectors have different indexes. 
+    # when creating the DataFrame. Will have no effect if Array is passed in
+    # the source, or if the passed Daru::Vectors have different indexes.
     # Default to *true*.
-    # 
+    #
     # == Usage
-    #   df = Daru::DataFrame.new({a: [1,2,3,4], b: [6,7,8,9]}, order: [:b, :a], 
+    #   df = Daru::DataFrame.new({a: [1,2,3,4], b: [6,7,8,9]}, order: [:b, :a],
     #     index: [:a, :b, :c, :d], name: :spider_man)
-    # 
-    #   # => 
+    #
+    #   # =>
     #   # <Daru::DataFrame:80766980 @name = spider_man @size = 4>
-    #   #             b          a 
-    #   #  a          6          1 
-    #   #  b          7          2 
-    #   #  c          8          3 
-    #   #  d          9          4 
+    #   #             b          a
+    #   #  a          6          1
+    #   #  b          7          2
+    #   #  c          8          3
+    #   #  d          9          4
     def initialize source, opts={}
       vectors = opts[:order]
       index   = opts[:index]
@@ -317,7 +317,7 @@ module Daru
               @vectors.each do |vector|
                 # avoids matching indexes of vectors if all the supplied vectors
                 # have the same index.
-                if vectors_have_same_index 
+                if vectors_have_same_index
                   v = source[vector].dup
                 else
                   v = Daru::Vector.new([], name: vector, index: @index)
@@ -356,8 +356,8 @@ module Daru
     end
 
     # Access row or vector. Specify name of row/vector followed by axis(:row, :vector).
-    # Defaults to *:vector*. Use of this method is not recommended for accessing 
-    # rows or vectors. Use df.row[:a] for accessing row with index ':a' or 
+    # Defaults to *:vector*. Use of this method is not recommended for accessing
+    # rows or vectors. Use df.row[:a] for accessing row with index ':a' or
     # df.vector[:vec] for accessing vector with index *:vec*.
     def [](*names)
       if names[-1] == :vector or names[-1] == :row
@@ -379,7 +379,7 @@ module Daru
     # Insert a new row/vector of the specified name or modify a previous row.
     # Instead of using this method directly, use df.row[:a] = [1,2,3] to set/create
     # a row ':a' to [1,2,3], or df.vector[:vec] = [1,2,3] for vectors.
-    # 
+    #
     # In case a Daru::Vector is specified after the equality the sign, the indexes
     # of the vector will be matched against the row/vector indexes of the DataFrame
     # before an insertion is performed. Unmatched indexes will be set to nil.
@@ -393,7 +393,7 @@ module Daru
 
       if axis == :vector
         insert_or_modify_vector name, vector
-      elsif axis == :row        
+      elsif axis == :row
         insert_or_modify_row name, vector
       else
         raise IndexError, "Expected axis to be row or vector, not #{axis}."
@@ -414,7 +414,7 @@ module Daru
     end
 
     # Access a row or set/create a row. Refer #[] and #[]= docs for details.
-    # 
+    #
     # == Usage
     #   df.row[:a] # access row named ':a'
     #   df.row[:b] = [1,2,3] # set row ':b' to [1,2,3]
@@ -423,17 +423,17 @@ module Daru
     end
 
     # Duplicate the DataFrame entirely.
-    # 
+    #
     # == Arguments
-    # 
-    # * +vectors_to_dup+ - An Array specifying the names of Vectors to 
+    #
+    # * +vectors_to_dup+ - An Array specifying the names of Vectors to
     # be duplicated. Will duplicate the entire DataFrame if not specified.
     def dup vectors_to_dup=nil
       vectors_to_dup = @vectors.to_a unless vectors_to_dup
 
       src = []
       vectors_to_dup.each do |vec|
-        src << @data[@vectors[vec]].to_a
+        src << @data[@vectors[vec]].to_a.dup
       end
       new_order = Daru::Index.new(vectors_to_dup)
 
@@ -447,9 +447,9 @@ module Daru
 
     # Returns a 'view' of the DataFrame, i.e the object ID's of vectors are
     # preserved.
-    # 
+    #
     # == Arguments
-    # 
+    #
     # +vectors_to_clone+ - Names of vectors to clone. Optional. Will return
     # a view of the whole data frame otherwise.
     def clone *vectors_to_clone
@@ -463,7 +463,7 @@ module Daru
       Daru::DataFrame.new(h, clone: false)
     end
 
-    # Returns a 'shallow' copy of DataFrame if missing data is not present, 
+    # Returns a 'shallow' copy of DataFrame if missing data is not present,
     # or a full copy of only valid data if missing data is present.
     def clone_only_valid
       if has_missing_data?
@@ -473,7 +473,7 @@ module Daru
       end
     end
 
-    # Creates a new duplicate dataframe containing only rows 
+    # Creates a new duplicate dataframe containing only rows
     # without a single missing value.
     def dup_only_valid vecs=nil
       rows_with_nil = @data.inject([]) do |memo, vector|
@@ -510,7 +510,7 @@ module Daru
 
       @vectors.each do |vector|
         yield @data[@vectors[vector]], vector
-      end 
+      end
 
       self
     end
@@ -543,12 +543,12 @@ module Daru
     #
     # == Description
     #
-    # `#each` works exactly like Array#each. The default mode for `each` 
-    # is to iterate over the columns of the DataFrame. To iterate over 
+    # `#each` works exactly like Array#each. The default mode for `each`
+    # is to iterate over the columns of the DataFrame. To iterate over
     # rows you must pass the axis, i.e `:row` as an argument.
-    # 
+    #
     # == Arguments
-    # 
+    #
     # * +axis+ - The axis to iterate over. Can be :vector (or :column)
     # or :row. Default to :vector.
     def each axis=:vector, &block
@@ -566,14 +566,14 @@ module Daru
     #
     # == Description
     #
-    # The #collect iterator works similar to #map, the only difference 
-    # being that it returns a Daru::Vector comprising of the results of 
-    # each block run. The resultant Vector has the same index as that 
-    # of the axis over which collect has iterated. It also accepts the 
+    # The #collect iterator works similar to #map, the only difference
+    # being that it returns a Daru::Vector comprising of the results of
+    # each block run. The resultant Vector has the same index as that
+    # of the axis over which collect has iterated. It also accepts the
     # optional axis argument.
     #
     # == Arguments
-    # 
+    #
     # * +axis+ - The axis to iterate over. Can be :vector (or :column)
     # or :row. Default to :vector.
     def collect axis=:vector, &block
@@ -590,16 +590,16 @@ module Daru
     # the argument specified. Will return an Array of the resulting
     # elements. To map over each row/vector and get a DataFrame,
     # see #recode.
-    # 
+    #
     # == Description
-    # 
-    # The #map iterator works like Array#map. The value returned by 
-    # each run of the block is added to an Array and the Array is 
-    # returned. This method also accepts an axis argument, like #each. 
+    #
+    # The #map iterator works like Array#map. The value returned by
+    # each run of the block is added to an Array and the Array is
+    # returned. This method also accepts an axis argument, like #each.
     # The default is :vector.
-    # 
+    #
     # == Arguments
-    # 
+    #
     # * +axis+ - The axis to map over. Can be :vector (or :column) or :row.
     # Default to :vector.
     def map axis=:vector, &block
@@ -615,9 +615,9 @@ module Daru
     # Destructive map. Modifies the DataFrame. Each run of the block
     # must return a Daru::Vector. You can specify the axis to map over
     # as the argument. Default to :vector.
-    # 
+    #
     # == Arguments
-    # 
+    #
     # * +axis+ - The axis to map over. Can be :vector (or :column) or :row.
     # Default to :vector.
     def map! axis=:vector, &block
@@ -634,15 +634,15 @@ module Daru
     #
     # == Description
     #
-    # Recode works similarly to #map, but an important difference between 
-    # the two is that recode returns a modified Daru::DataFrame instead 
-    # of an Array. For this reason, #recode expects that every run of the 
+    # Recode works similarly to #map, but an important difference between
+    # the two is that recode returns a modified Daru::DataFrame instead
+    # of an Array. For this reason, #recode expects that every run of the
     # block to return a Daru::Vector.
     #
     # Just like map and each, recode also accepts an optional _axis_ argument.
-    # 
+    #
     # == Arguments
-    # 
+    #
     # * +axis+ - The axis to map over. Can be :vector (or :column) or :row.
     # Default to :vector.
     def recode axis=:vector, &block
@@ -654,22 +654,22 @@ module Daru
     end
 
     # Retain vectors or rows if the block returns a truthy value.
-    # 
+    #
     # == Description
-    # 
-    # For filtering out certain rows/vectors based on their values, 
-    # use the #filter method. By default it iterates over vectors and 
-    # keeps those vectors for which the block returns true. It accepts 
-    # an optional axis argument which lets you specify whether you want 
+    #
+    # For filtering out certain rows/vectors based on their values,
+    # use the #filter method. By default it iterates over vectors and
+    # keeps those vectors for which the block returns true. It accepts
+    # an optional axis argument which lets you specify whether you want
     # to iterate over vectors or rows.
-    # 
+    #
     # == Arguments
-    # 
+    #
     # * +axis+ - The axis to map over. Can be :vector (or :column) or :row.
     # Default to :vector.
-    # 
+    #
     # == Usage
-    # 
+    #
     #   # Filter vectors
     #
     #   df.filter do |vector|
@@ -690,12 +690,12 @@ module Daru
     end
 
     def recode_vectors &block
-      block_given? or return to_enum(:recode_vectors) 
+      block_given? or return to_enum(:recode_vectors)
 
       df = self.dup
       df.each_vector_with_index do |v, i|
         ret = yield v
-        ret.is_a?(Daru::Vector) or 
+        ret.is_a?(Daru::Vector) or
           raise TypeError, "Every iteration must return Daru::Vector not #{ret.class}"
         df[*i] = ret
       end
@@ -788,7 +788,7 @@ module Daru
       self
     end
 
-    # Retrieves a Daru::Vector, based on the result of calculation 
+    # Retrieves a Daru::Vector, based on the result of calculation
     # performed on each row.
     def collect_rows &block
       return to_enum(:collect_rows) unless block_given?
@@ -903,15 +903,15 @@ module Daru
 
         deletion << index unless keep_row
       end
-      deletion.each { |idx| 
-        delete_row idx 
+      deletion.each { |idx|
+        delete_row idx
       }
     end
 
     def keep_vector_if &block
       @vectors.each do |vector|
         keep_vector = yield @data[@vectors[vector]], vector
-        
+
         delete_vector vector unless keep_vector
       end
     end
@@ -950,7 +950,7 @@ module Daru
     # true for that vector.
     def filter_vectors &block
       return to_enum(:filter_vectors) unless block_given?
-      
+
       df = self.dup
       df.keep_vector_if &block
 
@@ -959,7 +959,7 @@ module Daru
 
     # Test each row with one or more tests. Each test is a Proc with the form
     # *Proc.new {|row| row[:age] > 0}*
-    # 
+    #
     # The function returns an array with all errors.
     def verify(*tests)
       if(tests[0].is_a? Symbol)
@@ -988,9 +988,9 @@ module Daru
 
     # DSL for yielding each row and returning a Daru::Vector based on the
     # value each run of the block returns.
-    # 
+    #
     # == Usage
-    # 
+    #
     #   a1 = Daru::Vector.new([1, 2, 3, 4, 5, 6, 7])
     #   a2 = Daru::Vector.new([10, 20, 30, 40, 50, 60, 70])
     #   a3 = Daru::Vector.new([100, 200, 300, 400, 500, 600, 700])
@@ -1016,10 +1016,10 @@ module Daru
 
     # Returns a vector, based on a string with a calculation based
     # on vector.
-    # 
+    #
     # The calculation will be eval'ed, so you can put any variable
     # or expression valid on ruby.
-    # 
+    #
     # For example:
     #   a = Daru::Vector.new [1,2]
     #   b = Daru::Vector.new [3,4]
@@ -1028,14 +1028,14 @@ module Daru
     #   => Vector [4,6]
     def compute text, &block
       return instance_eval(&block) if block_given?
-      instance_eval(text) 
+      instance_eval(text)
     end
 
     # Return a vector with the number of missing values in each row.
-    # 
+    #
     # == Arguments
-    # 
-    # * +missing_values+ - An Array of the values that should be 
+    #
+    # * +missing_values+ - An Array of the values that should be
     # treated as 'missing'. The default missing value is *nil*.
     def missing_values_rows missing_values=[nil]
       number_of_missing = []
@@ -1056,9 +1056,9 @@ module Daru
 
     alias :flawed? :has_missing_data?
 
-    # Return a nested hash using vector names as keys and an array constructed of 
+    # Return a nested hash using vector names as keys and an array constructed of
     # hashes with other values. If block provided, is used to provide the
-    # values, with parameters +row+ of dataset, +current+ last hash on 
+    # values, with parameters +row+ of dataset, +current+ last hash on
     # hierarchy and +name+ of the key to include
     def nest *tree_keys, &block
       tree_keys = tree_keys[0] if tree_keys[0].is_a? Array
@@ -1126,7 +1126,7 @@ module Daru
     # @example Using any?
     #   df = Daru::DataFrame.new({a: [1,2,3,4,5], b: ['a', 'b', 'c', 'd', 'e']})
     #   df.any?(:row) do |row|
-    #     row[:a] < 3 and row[:b] == 'b' 
+    #     row[:a] < 3 and row[:b] == 'b'
     #   end #=> true
     def any? axis=:vector, &block
       if axis == :vector or axis == :column
@@ -1148,7 +1148,7 @@ module Daru
     # @example Using all?
     #   df = Daru::DataFrame.new({a: [1,2,3,4,5], b: ['a', 'b', 'c', 'd', 'e']})
     #   df.all?(:row) do |row|
-    #     row[:a] < 10 
+    #     row[:a] < 10
     #   end #=> true
     def all? axis=:vector, &block
       if axis == :vector or axis == :column
@@ -1171,13 +1171,13 @@ module Daru
     end
 
     # The last ten elements of the DataFrame
-    # 
+    #
     # @param [Fixnum] quantity (10) The number of elements to display from the bottom.
     def tail quantity=10
       self[(@size - quantity)..(@size-1), :row]
     end
 
-    # Returns a vector with sum of all vectors specified in the argument. 
+    # Returns a vector with sum of all vectors specified in the argument.
     # Tf vecs parameter is empty, sum all numeric vector.
     def vector_sum vecs=nil
       vecs ||= numeric_vectors
@@ -1191,9 +1191,9 @@ module Daru
     end
 
     # Calculate mean of the rows of the dataframe.
-    # 
+    #
     # == Arguments
-    # 
+    #
     # * +max_missing+ - The maximum number of elements in the row that can be
     # zero for the mean calculation to happen. Default to 0.
     def vector_mean max_missing=0
@@ -1206,16 +1206,16 @@ module Daru
       mean_vec
     end
 
-    # Group elements by vector to perform operations on them. Returns a 
+    # Group elements by vector to perform operations on them. Returns a
     # Daru::Core::GroupBy object.See the Daru::Core::GroupBy docs for a detailed
     # list of possible operations.
-    # 
+    #
     # == Arguments
-    # 
+    #
     # * vectors - An Array contatining names of vectors to group by.
-    # 
+    #
     # == Usage
-    # 
+    #
     #   df = Daru::DataFrame.new({
     #     a: %w{foo bar foo bar   foo bar foo foo},
     #     b: %w{one one two three two two one three},
@@ -1234,7 +1234,7 @@ module Daru
       vectors.flatten!
       vectors.each { |v| raise(ArgumentError, "Vector #{v} does not exist") unless
         has_vector?(v) }
-        
+
       Daru::Core::GroupBy.new(self, vectors)
     end
 
@@ -1267,9 +1267,9 @@ module Daru
 
     # Set a particular column as the new DF
     def set_index new_index, opts={}
-      raise ArgumentError, "All elements in new index must be unique." if 
+      raise ArgumentError, "All elements in new index must be unique." if
         @size != self[new_index].uniq.size
-      
+
       self.index = Daru::Index.new(self[new_index].to_a)
       self.delete_vector(new_index) unless opts[:keep]
 
@@ -1278,25 +1278,25 @@ module Daru
 
     # Change the index of the DataFrame and preserve the labels of the previous
     # indexing. New index can be Daru::Index or any of its subclasses.
-    # 
+    #
     # @param [Daru::Index] new_index The new Index for reindexing the DataFrame.
     # @example Reindexing DataFrame
-    #   df = Daru::DataFrame.new({a: [1,2,3,4], b: [11,22,33,44]}, 
+    #   df = Daru::DataFrame.new({a: [1,2,3,4], b: [11,22,33,44]},
     #     index: ['a','b','c','d'])
-    #   #=> 
+    #   #=>
     #   ##<Daru::DataFrame:83278130 @name = b19277b8-c548-41da-ad9a-2ad8c060e273 @size = 4>
-    #   #                    a          b 
-    #   #         a          1         11 
-    #   #         b          2         22 
-    #   #         c          3         33 
-    #   #         d          4         44 
+    #   #                    a          b
+    #   #         a          1         11
+    #   #         b          2         22
+    #   #         c          3         33
+    #   #         d          4         44
     #   df.reindex Daru::Index.new(['b', 0, 'a', 'g'])
-    #   #=> 
+    #   #=>
     #   ##<Daru::DataFrame:83177070 @name = b19277b8-c548-41da-ad9a-2ad8c060e273 @size = 4>
-    #   #                    a          b 
-    #   #         b          2         22 
-    #   #         0        nil        nil 
-    #   #         a          1         11 
+    #   #                    a          b
+    #   #         b          2         22
+    #   #         0        nil        nil
+    #   #         a          1         11
     #   #         g        nil        nil
     def reindex new_index
       raise ArgumentError, "Must pass the new index of type Index or its "\
@@ -1321,10 +1321,10 @@ module Daru
     # @example Reassgining index of a DataFrame
     #   df = Daru::DataFrame.new({a: [1,2,3,4], b: [11,22,33,44]})
     #   df.index.to_a #=> [0,1,2,3]
-    # 
+    #
     #   df.index = Daru::Index.new(['a','b','c','d'])
     #   df.index.to_a #=> ['a','b','c','d']
-    #   df.row['a'].to_a #=> [1,11] 
+    #   df.row['a'].to_a #=> [1,11]
     def index= idx
       @data.each { |vec| vec.index = idx}
       @index = idx
@@ -1333,17 +1333,17 @@ module Daru
     end
 
     # Reassign vectors with a new index of type Daru::Index or any of its subclasses.
-    # 
+    #
     # @param [Daru::Index] idx The new index object on which the vectors are to
     #   be indexed. Must of the same size as ncols.
     # @example Reassigning vectors of a DataFrame
     #   df = Daru::DataFrame.new({a: [1,2,3,4], b: [:a,:b,:c,:d], c: [11,22,33,44]})
     #   df.vectors.to_a #=> [:a, :b, :c]
-    # 
+    #
     #   df.vectors = Daru::Index.new([:foo, :bar, :baz])
     #   df.vectors.to_a #=> [:foo, :bar, :baz]
     def vectors= idx
-      raise ArgumentError, "Can only reindex with Index and its subclasses" unless 
+      raise ArgumentError, "Can only reindex with Index and its subclasses" unless
         index.kind_of?(Daru::Index)
       raise ArgumentError, "Specified index length #{idx.size} not equal to"\
         "dataframe size #{ncols}" if idx.size != ncols
@@ -1402,9 +1402,9 @@ module Daru
       end
     end
 
-    # Sorts a dataframe (ascending/descending)according to the given sequence of 
+    # Sorts a dataframe (ascending/descending)according to the given sequence of
     # vectors, using the attributes provided in the blocks.
-    # 
+    #
     # @param order [Array] The order of vector names in which the DataFrame
     #   should be sorted.
     # @param [Hash] opts The options to sort with.
@@ -1412,21 +1412,21 @@ module Daru
     #   or descending order. Specify Array corresponding to *order* for multiple
     #   sort orders.
     # @option opts [Hash] :by ({|a,b| a <=> b}) Specify attributes of objects to
-    #   to be used for sorting, for each vector name in *order* as a hash of 
+    #   to be used for sorting, for each vector name in *order* as a hash of
     #   vector name and lambda pairs. In case a lambda for a vector is not
     #   specified, the default will be used.
-    # 
+    #
     # == Usage
-    #   
+    #
     #   df = Daru::DataFrame.new({a: [-3,2,-1,4], b: [4,3,2,1]})
-    #   
+    #
     #   #<Daru::DataFrame:140630680 @name = 04e00197-f8d5-4161-bca2-93266bfabc6f @size = 4>
-    #   #            a          b 
-    #   # 0         -3          4 
-    #   # 1          2          3 
-    #   # 2         -1          2 
-    #   # 3          4          1 
-    #   df.sort([:a], by: { a: lambda { |a,b| a.abs <=> b.abs } })  
+    #   #            a          b
+    #   # 0         -3          4
+    #   # 1          2          3
+    #   # 2         -1          2
+    #   # 3          4          1
+    #   df.sort([:a], by: { a: lambda { |a,b| a.abs <=> b.abs } })
     def sort! vector_order, opts={}
       raise ArgumentError, "Required atleast one vector name" if vector_order.size < 1
       opts = {
@@ -1451,46 +1451,46 @@ module Daru
 
     # Pivots a data frame on specified vectors and applies an aggregate function
     # to quickly generate a summary.
-    # 
+    #
     # == Options
-    # 
+    #
     # +:index+ - Keys to group by on the pivot table row index. Pass vector names
     # contained in an Array.
-    # 
+    #
     # +:vectors+ - Keys to group by on the pivot table column index. Pass vector
     # names contained in an Array.
-    # 
+    #
     # +:agg+ - Function to aggregate the grouped values. Default to *:mean*. Can
-    # use any of the statistics functions applicable on Vectors that can be found in 
+    # use any of the statistics functions applicable on Vectors that can be found in
     # the Daru::Statistics::Vector module.
-    # 
-    # +:values+ - Columns to aggregate. Will consider all numeric columns not 
+    #
+    # +:values+ - Columns to aggregate. Will consider all numeric columns not
     # specified in *:index* or *:vectors*. Optional.
-    # 
+    #
     # == Usage
-    # 
+    #
     #   df = Daru::DataFrame.new({
-    #     a: ['foo'  ,  'foo',  'foo',  'foo',  'foo',  'bar',  'bar',  'bar',  'bar'], 
+    #     a: ['foo'  ,  'foo',  'foo',  'foo',  'foo',  'bar',  'bar',  'bar',  'bar'],
     #     b: ['one'  ,  'one',  'one',  'two',  'two',  'one',  'one',  'two',  'two'],
     #     c: ['small','large','large','small','small','large','small','large','small'],
     #     d: [1,2,2,3,3,4,5,6,7],
     #     e: [2,4,4,6,6,8,10,12,14]
     #   })
     #   df.pivot_table(index: [:a], vectors: [:b], agg: :sum, values: :e)
-    # 
-    #   #=> 
+    #
+    #   #=>
     #   # #<Daru::DataFrame:88342020 @name = 08cdaf4e-b154-4186-9084-e76dd191b2c9 @size = 2>
-    #   #            [:e, :one] [:e, :two] 
-    #   #     [:bar]         18         26 
-    #   #     [:foo]         10         12 
+    #   #            [:e, :one] [:e, :two]
+    #   #     [:bar]         18         26
+    #   #     [:foo]         10         12
     def pivot_table opts={}
-      raise ArgumentError, 
+      raise ArgumentError,
         "Specify grouping index" if !opts[:index] or opts[:index].empty?
 
       index   = opts[:index]
       vectors = opts[:vectors] || []
       aggregate_function = opts[:agg] || :mean
-      values = 
+      values =
       if opts[:values].is_a?(Symbol)
         [opts[:values]]
       elsif opts[:values].is_a?(Array)
@@ -1498,7 +1498,7 @@ module Daru
       else # nil
         (@vectors.to_a - (index | vectors)) & numeric_vector_names
       end
-      
+
       raise IndexError, "No numeric vectors to aggregate" if values.empty?
 
       grouped  = group_by(index)
@@ -1549,7 +1549,7 @@ module Daru
       end
     end
 
-    # Merge vectors from two DataFrames. In case of name collision, 
+    # Merge vectors from two DataFrames. In case of name collision,
     # the vectors names are changed to x_1, x_2 ....
     #
     # @return {Daru::DataFrame}
@@ -1570,9 +1570,9 @@ module Daru
       df_new
     end
 
-    # Join 2 DataFrames with SQL style joins. Currently supports inner, left 
+    # Join 2 DataFrames with SQL style joins. Currently supports inner, left
     # outer, right outer and full outer joins.
-    # 
+    #
     # @param [Daru::DataFrame] other_df Another DataFrame on which the join is
     #   to be performed.
     # @param [Hash] opts Options Hash
@@ -1590,11 +1590,11 @@ module Daru
     #     :name => ['Rutabaga', 'Pirate', 'Darth Vader', 'Ninja']
     #   })
     #   left.join(right, how: :inner, on: [:name])
-    #   #=> 
+    #   #=>
     #   ##<Daru::DataFrame:82416700 @name = 74c0811b-76c6-4c42-ac93-e6458e82afb0 @size = 2>
-    #   #                 id_1       name       id_2 
-    #   #         0          1     Pirate          2 
-    #   #         1          3      Ninja          4 
+    #   #                 id_1       name       id_2
+    #   #         0          1     Pirate          2
+    #   #         1          3      Ninja          4
     def join(other_df,opts={})
       Daru::Core::Merge.join(self, other_df, opts)
     end
@@ -1611,7 +1611,7 @@ module Daru
     # the field of first parameters will be copied verbatim
     # to new dataset, and fields which responds to second
     # pattern will be added one case for each different %n.
-    # 
+    #
     # @example
     #   cases=[
     #     ['1','george','red',10,'blue',20,nil,nil],
@@ -1632,9 +1632,9 @@ module Daru
       ds_vars = parent_fields.dup
       vars    = []
       max_n   = 0
-      h       = parent_fields.inject({}) { |a,v| 
+      h       = parent_fields.inject({}) { |a,v|
         a[v] = Daru::Vector.new([])
-        a 
+        a
       }
       # Adding _row_id
       h['_col_id'] = Daru::Vector.new([])
@@ -1688,12 +1688,12 @@ module Daru
     end
 
     # Create a sql, basen on a given Dataset
-    # 
+    #
     # == Arguments
-    # 
+    #
     # * table - String specifying name of the table that will created in SQL.
     # * charset - Character set. Default is "UTF8".
-    # 
+    #
     # @example
     #
     #  ds = Daru::DataFrame.new({
@@ -1742,17 +1742,17 @@ module Daru
     def to_nmatrix
       numerics_as_arrays = []
       each_vector do |vector|
-        numerics_as_arrays << vector.to_a if(vector.type == :numeric and 
+        numerics_as_arrays << vector.to_a if(vector.type == :numeric and
           vector.missing_positions.size == 0)
       end
 
       numerics_as_arrays.transpose.to_nm
     end
-    
+
     # Converts the DataFrame into an array of hashes where key is vector name
-    # and value is the corresponding element. The 0th index of the array contains 
-    # the array of hashes while the 1th index contains the indexes of each row 
-    # of the dataframe. Each element in the index array corresponds to its row 
+    # and value is the corresponding element. The 0th index of the array contains
+    # the array of hashes while the 1th index contains the indexes of each row
+    # of the dataframe. Each element in the index array corresponds to its row
     # in the array of hashes, which has the same index.
     def to_a
       arry = [[],[]]
@@ -1787,10 +1787,10 @@ module Daru
 
     # Convert to html for IRuby.
     def to_html threshold=30
-      html = "<table>" + 
+      html = "<table>" +
         "<tr>" +
-          "<th colspan=\"#{@vectors.size+1}\">" + 
-            "Daru::DataFrame:#{self.object_id} " + " rows: #{nrows} " + " cols: #{ncols}" 
+          "<th colspan=\"#{@vectors.size+1}\">" +
+            "Daru::DataFrame:#{self.object_id} " + " rows: #{nrows} " + " cols: #{ncols}"
           "</th>" +
         "</tr>"
       html +='<tr><th></th>'
@@ -1816,7 +1816,7 @@ module Daru
           html += '<tr>'
           html += "<td>" + last_index.to_s + "</td>"
           (0..(ncols - 1)).to_a.each do |i|
-            html += '<td>' + last_row[i].to_s + '</td>' 
+            html += '<td>' + last_row[i].to_s + '</td>'
           end
           html += '</tr>'
           break
@@ -1850,21 +1850,21 @@ module Daru
     # == Arguements
     #
     # * filename - Path of CSV file where the DataFrame is to be saved.
-    # 
+    #
     # == Options
-    # 
+    #
     # * convert_comma - If set to *true*, will convert any commas in any
     # of the data to full stops ('.').
-    # All the options accepted by CSV.read() can also be passed into this 
+    # All the options accepted by CSV.read() can also be passed into this
     # function.
     def write_csv filename, opts={}
       Daru::IO.dataframe_write_csv self, filename, opts
     end
 
     # Write this dataframe to an Excel Spreadsheet
-    # 
+    #
     # == Arguments
-    # 
+    #
     # * filename - The path of the file where the DataFrame should be written.
     def write_excel filename, opts={}
       Daru::IO.dataframe_write_excel self, filename, opts
@@ -1873,10 +1873,10 @@ module Daru
     # Insert each case of the Dataset on the selected table
     #
     # == Arguments
-    # 
+    #
     # * dbh - DBI database connection object.
     # * query - Query string.
-    # 
+    #
     # == Usage
     #
     #  ds = Daru::DataFrame.new({:id=>Daru::Vector.new([1,2,3]), :name=>Daru::Vector.new(["a","b","c"])})
@@ -1894,8 +1894,8 @@ module Daru
 
     def _dump depth
       Marshal.dump({
-        data:  @data, 
-        index: @index.to_a, 
+        data:  @data,
+        index: @index.to_a,
         order: @vectors.to_a,
         name:  @name
         })
@@ -1903,14 +1903,14 @@ module Daru
 
     def self._load data
       h = Marshal.load data
-      Daru::DataFrame.new(h[:data], 
-        index: h[:index], 
+      Daru::DataFrame.new(h[:data],
+        index: h[:index],
         order: h[:order],
         name:  h[:name])
     end
 
     # Change dtypes of vectors by supplying a hash of :vector_name => :new_dtype
-    # 
+    #
     # == Usage
     #   df = Daru::DataFrame.new({a: [1,2,3], b: [1,2,3], c: [1,2,3]})
     #   df.recast a: :nmatrix, c: :nmatrix
@@ -1933,7 +1933,7 @@ module Daru
     # Pretty print in a nice table format for the command line (irb/pry/iruby)
     def inspect spacing=10, threshold=15
       longest = [@name.to_s.size,
-                 (@vectors.map(&:to_s).map(&:size).max || 0), 
+                 (@vectors.map(&:to_s).map(&:size).max || 0),
                  (@index  .map(&:to_s).map(&:size).max || 0),
                  (@data   .map{ |v| v.map(&:to_s).map(&:size).max}.max || 0)].max
 
@@ -1943,7 +1943,7 @@ module Daru
       formatter = "\n"
 
       (@vectors.size + 1).times { formatter += "%#{longest}.#{longest}s " }
-      content += "\n#<" + self.class.to_s + ":" + self.object_id.to_s + " @name = " + 
+      content += "\n#<" + self.class.to_s + ":" + self.object_id.to_s + " @name = " +
                     name.to_s + " @size = " + @size.to_s + ">"
       content += sprintf formatter, "" , *@vectors.map(&:to_s)
       row_num  = 1
@@ -1970,10 +1970,10 @@ module Daru
     end
 
     def == other
-      self.class == other.class   and 
-      @size      == other.size    and 
+      self.class == other.class   and
+      @size      == other.size    and
       @index     == other.index   and
-      @vectors   == other.vectors and 
+      @vectors   == other.vectors and
       @vectors.to_a.all? { |v| self[v] == other[v] }
     end
 
@@ -2002,9 +2002,9 @@ module Daru
     end
 
     # == Arguments
-    # 
-    # vector_order - 
-    # index - 
+    #
+    # vector_order -
+    # index -
     # by -
     # ascending -
     # left_lower -
@@ -2145,7 +2145,7 @@ module Daru
         end
 
         order = names.is_a?(Array) ? Daru::Index.new(names) : names
-        Daru::DataFrame.new(new_vcs, order: order, 
+        Daru::DataFrame.new(new_vcs, order: order,
           index: @index, name: @name)
       end
     end
@@ -2159,7 +2159,7 @@ module Daru
           return Daru::Vector.new(populate_row_for(pos), index: @vectors, name: pos)
         else
           new_rows = pos.map { |tuple| populate_row_for(tuple) }
-          
+
           if !location.is_a?(Range) and names.size < @index.width
             pos = pos.drop_left_level names.size
           end
@@ -2168,7 +2168,7 @@ module Daru
             new_rows, order: @vectors, name: @name, index: pos)
         end
       else
-        if names[1].nil? 
+        if names[1].nil?
           names = @index[location]
           if names.is_a?(Numeric)
             row = []
@@ -2184,8 +2184,8 @@ module Daru
         names.each do |name|
           rows << self.row[name].to_a
         end
-        
-        Daru::DataFrame.rows rows, index: names ,name: @name, order: @vectors        
+
+        Daru::DataFrame.rows rows, index: names ,name: @name, order: @vectors
       end
     end
 
@@ -2196,11 +2196,11 @@ module Daru
     end
 
     def insert_or_modify_vector name, vector
-      name = name[0] unless @vectors.is_a?(MultiIndex)   
+      name = name[0] unless @vectors.is_a?(MultiIndex)
       v = nil
 
       if @index.empty?
-        v = vector.is_a?(Daru::Vector) ? vector : Daru::Vector.new(vector.to_a)  
+        v = vector.is_a?(Daru::Vector) ? vector : Daru::Vector.new(vector.to_a)
         @index = v.index
         assign_or_add_vector name, v
         set_size
@@ -2242,7 +2242,7 @@ module Daru
       #FIXME: fix this jugaad. need to make changes in Indexing itself.
       pos = @vectors[name]
 
-      if !pos.kind_of?(Daru::Index) and pos == name and 
+      if !pos.kind_of?(Daru::Index) and pos == name and
         (@vectors.include?(name) or (pos.is_a?(Integer) and pos < @data.size))
         @data[pos] = v
       elsif pos.kind_of?(Daru::Index)
@@ -2252,10 +2252,10 @@ module Daru
       else
         @vectors = @vectors | [name] if !@vectors.include?(name)
         @data[@vectors[name]] = v
-      end      
+      end
     end
 
-    def insert_or_modify_row name, vector    
+    def insert_or_modify_row name, vector
       if index.is_a?(MultiIndex)
         # TODO
       else
@@ -2289,7 +2289,7 @@ module Daru
     end
 
     def validate_labels
-      raise IndexError, "Expected equal number of vector names (#{@vectors.size}) for number of vectors (#{@data.size})." if 
+      raise IndexError, "Expected equal number of vector names (#{@vectors.size}) for number of vectors (#{@data.size})." if
         @vectors and @vectors.size != @data.size
 
       raise IndexError, "Expected number of indexes same as number of rows" if
@@ -2355,7 +2355,7 @@ module Daru
     end
 
     def symbolize arry
-      symbolized_arry = 
+      symbolized_arry =
       if arry.all? { |e| e.is_a?(Array) }
         arry.map do |sub_arry|
           sub_arry.map do |e|

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper.rb'
 
 describe Daru::DataFrame do
   before :each do
-    @data_frame = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5], 
-      c: [11,22,33,44,55]}, 
-      order: [:a, :b, :c], 
+    @data_frame = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5],
+      c: [11,22,33,44,55]},
+      order: [:a, :b, :c],
       index: [:one, :two, :three, :four, :five])
     tuples = [
       [:a,:one,:bar],
@@ -32,14 +32,14 @@ describe Daru::DataFrame do
       [:b,:one,:foo]])
 
     @df_mi = Daru::DataFrame.new([
-      @vector_arry1, 
-      @vector_arry2, 
-      @vector_arry1, 
+      @vector_arry1,
+      @vector_arry2,
+      @vector_arry1,
       @vector_arry2], order: @order_mi, index: @multi_index)
   end
 
   context ".rows" do
-    before do 
+    before do
       @rows = [
         [1,2,3,4,5],
         [1,2,3,4,5],
@@ -80,9 +80,9 @@ describe Daru::DataFrame do
 
       it "crates a DataFrame from rows (MultiIndex order)" do
         rows = [
-          [11, 1, 11, 1], 
-          [12, 2, 12, 2], 
-          [13, 3, 13, 3], 
+          [11, 1, 11, 1],
+          [12, 2, 12, 2],
+          [13, 3, 13, 3],
           [14, 4, 14, 4]
         ]
         index = Daru::MultiIndex.from_tuples([
@@ -119,7 +119,7 @@ describe Daru::DataFrame do
 
         expect(df.vectors).to eq(Daru::Index.new [:a, :b])
         expect(df.a.class).to eq(Daru::Vector)
-        expect(df.a)      .to eq([].dv(:a)) 
+        expect(df.a)      .to eq([].dv(:a))
       end
 
       it "initializes from a Hash" do
@@ -129,29 +129,29 @@ describe Daru::DataFrame do
         expect(df.index)  .to eq(Daru::Index.new [:one, :two, :three, :four, :five])
         expect(df.vectors).to eq(Daru::Index.new [:a, :b])
         expect(df.a.class).to eq(Daru::Vector)
-        expect(df.a)      .to eq([1,2,3,4,5].dv(:a, df.index)) 
+        expect(df.a)      .to eq([1,2,3,4,5].dv(:a, df.index))
       end
 
       it "initializes from a Hash of Vectors" do
-        df = Daru::DataFrame.new({b: [11,12,13,14,15].dv(:b, [:one, :two, :three, :four, :five]), 
+        df = Daru::DataFrame.new({b: [11,12,13,14,15].dv(:b, [:one, :two, :three, :four, :five]),
           a: [1,2,3,4,5].dv(:a, [:one, :two, :three, :four, :five])}, order: [:a, :b],
           index: [:one, :two, :three, :four, :five])
 
         expect(df.index)  .to eq(Daru::Index.new [:one, :two, :three, :four, :five])
         expect(df.vectors).to eq(Daru::Index.new [:a, :b])
         expect(df.a.class).to eq(Daru::Vector)
-        expect(df.a)      .to eq([1,2,3,4,5].dv(:a, [:one, :two, :three, :four, :five])) 
+        expect(df.a)      .to eq([1,2,3,4,5].dv(:a, [:one, :two, :three, :four, :five]))
       end
 
       it "initializes from an Array of Hashes" do
         df = Daru::DataFrame.new([{a: 1, b: 11}, {a: 2, b: 12}, {a: 3, b: 13},
-          {a: 4, b: 14}, {a: 5, b: 15}], order: [:b, :a], 
+          {a: 4, b: 14}, {a: 5, b: 15}], order: [:b, :a],
           index: [:one, :two, :three, :four, :five])
 
         expect(df.index)  .to eq(Daru::Index.new [:one, :two, :three, :four, :five])
         expect(df.vectors).to eq(Daru::Index.new [:b, :a])
         expect(df.a.class).to eq(Daru::Vector)
-        expect(df.a)      .to eq([1,2,3,4,5].dv(:a,[:one, :two, :three, :four, :five])) 
+        expect(df.a)      .to eq([1,2,3,4,5].dv(:a,[:one, :two, :three, :four, :five]))
       end
 
       it "initializes from Array of Arrays" do
@@ -175,7 +175,7 @@ describe Daru::DataFrame do
         rows = Daru::Index.new [:one, :two, :three, :four, :five]
         cols = Daru::Index.new [:a, :b]
 
-        df  = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5]}, order: cols, 
+        df  = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5]}, order: cols,
           index: rows)
 
         expect(df.a)      .to eq(Daru::Vector.new([1,2,3,4,5], order: [:a], index: rows))
@@ -193,14 +193,14 @@ describe Daru::DataFrame do
 
       it "aligns indexes properly" do
         df = Daru::DataFrame.new({
-            b: [11,12,13,14,15].dv(:b, [:two, :one, :four, :five, :three]), 
+            b: [11,12,13,14,15].dv(:b, [:two, :one, :four, :five, :three]),
             a:      [1,2,3,4,5].dv(:a, [:two,:one,:three, :four, :five])
-          }, 
+          },
             order: [:a, :b]
           )
 
         expect(df).to eq(Daru::DataFrame.new({
-            b: [14,13,12,15,11].dv(:b, [:five, :four, :one, :three, :two]), 
+            b: [14,13,12,15,11].dv(:b, [:five, :four, :one, :three, :two]),
             a:      [5,4,2,3,1].dv(:a, [:five, :four, :one, :three, :two])
           }, order: [:a, :b])
         )
@@ -208,43 +208,43 @@ describe Daru::DataFrame do
 
       it "adds nil values for missing indexes and aligns by index" do
         df = Daru::DataFrame.new({
-                 b: [11,12,13,14,15].dv(:b, [:two, :one, :four, :five, :three]), 
+                 b: [11,12,13,14,15].dv(:b, [:two, :one, :four, :five, :three]),
                  a: [1,2,3]         .dv(:a, [:two,:one,:three])
-               }, 
+               },
                order: [:a, :b]
              )
 
         expect(df).to eq(Daru::DataFrame.new({
-            b: [14,13,12,15,11].dv(:b, [:five, :four, :one, :three, :two]), 
+            b: [14,13,12,15,11].dv(:b, [:five, :four, :one, :three, :two]),
             a:  [nil,nil,2,3,1].dv(:a, [:five, :four, :one, :three, :two])
-          }, 
+          },
           order: [:a, :b])
         )
       end
 
       it "adds nils in first vector when other vectors have many extra indexes" do
         df = Daru::DataFrame.new({
-            b: [11]                .dv(nil, [:one]), 
-            a: [1,2,3]             .dv(nil, [:one, :two, :three]), 
+            b: [11]                .dv(nil, [:one]),
+            a: [1,2,3]             .dv(nil, [:one, :two, :three]),
             c: [11,22,33,44,55]    .dv(nil, [:one, :two, :three, :four, :five]),
             d: [49,69,89,99,108,44].dv(nil, [:one, :two, :three, :four, :five, :six])
-          }, order: [:a, :b, :c, :d], 
+          }, order: [:a, :b, :c, :d],
           index: [:one, :two, :three, :four, :five, :six])
 
         expect(df).to eq(Daru::DataFrame.new({
-            b: [11,nil,nil,nil,nil,nil].dv(nil, [:one, :two, :three, :four, :five, :six]), 
-            a: [1,2,3,nil,nil,nil]     .dv(nil, [:one, :two, :three, :four, :five, :six]), 
+            b: [11,nil,nil,nil,nil,nil].dv(nil, [:one, :two, :three, :four, :five, :six]),
+            a: [1,2,3,nil,nil,nil]     .dv(nil, [:one, :two, :three, :four, :five, :six]),
             c: [11,22,33,44,55,nil]    .dv(nil, [:one, :two, :three, :four, :five, :six]),
             d: [49,69,89,99,108,44]    .dv(nil, [:one, :two, :three, :four, :five, :six])
-          }, order: [:a, :b, :c, :d], 
+          }, order: [:a, :b, :c, :d],
           index: [:one, :two, :three, :four, :five, :six])
         )
       end
 
       it "correctly matches the supplied DataFrame index with the individual vector indexes" do
         df = Daru::DataFrame.new({
-            b: [11,12,13] .dv(nil, [:one, :bleh, :blah]), 
-            a: [1,2,3,4,5].dv(nil, [:one, :two, :booh, :baah, :three]), 
+            b: [11,12,13] .dv(nil, [:one, :bleh, :blah]),
+            a: [1,2,3,4,5].dv(nil, [:one, :two, :booh, :baah, :three]),
             c: [11,22,33,44,55].dv(nil, [0,1,3,:three, :two])
           }, order: [:a, :b, :c], index: [:one, :two, :three])
 
@@ -252,14 +252,14 @@ describe Daru::DataFrame do
             b: [11,nil,nil].dv(nil, [:one, :two, :three]),
             a: [1,2,5]     .dv(nil, [:one, :two, :three]),
             c: [nil,55,44] .dv(nil, [:one, :two, :three]),
-          },  
+          },
           order: [:a, :b, :c], index: [:one, :two, :three]
           )
         )
       end
 
       it "completes incomplete vectors" do
-        df = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5], 
+        df = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5],
           c: [11,22,33,44,55]}, order: [:a, :c])
 
         expect(df.vectors).to eq([:a,:c,:b].to_index)
@@ -270,7 +270,7 @@ describe Daru::DataFrame do
         b = Daru::Vector.new([1,2,3,4,5])
         c = Daru::Vector.new([1,2,3,4,5])
         df = Daru::DataFrame.new({a: a, b: b, c: c}, clone: false)
-        
+
         expect(df[:a].object_id).to eq(a.object_id)
         expect(df[:b].object_id).to eq(b.object_id)
         expect(df[:c].object_id).to eq(c.object_id)
@@ -298,21 +298,21 @@ describe Daru::DataFrame do
 
       it "raises error for incomplete DataFrame index" do
         expect {
-          df = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5], 
-            c: [11,22,33,44,55]}, order: [:a, :b, :c], 
+          df = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5],
+            c: [11,22,33,44,55]}, order: [:a, :b, :c],
             index: [:one, :two, :three])
         }.to raise_error
       end
 
       it "raises error for unequal sized vectors/arrays" do
         expect {
-          df = Daru::DataFrame.new({b: [11,12,13], a: [1,2,3,4,5], 
-            c: [11,22,33,44,55]}, order: [:a, :b, :c], 
+          df = Daru::DataFrame.new({b: [11,12,13], a: [1,2,3,4,5],
+            c: [11,22,33,44,55]}, order: [:a, :b, :c],
             index: [:one, :two, :three])
         }.to raise_error
       end
     end
-    
+
     context Daru::MultiIndex do
       it "creates empty DataFrame" do
         df = Daru::DataFrame.new({}, order: @order_mi)
@@ -323,15 +323,15 @@ describe Daru::DataFrame do
 
       it "creates from Hash" do
         df = Daru::DataFrame.new({
-          [:a,:one,:bar] => @vector_arry1, 
-          [:a,:two,:baz] => @vector_arry2, 
-          [:b,:one,:foo] => @vector_arry1, 
+          [:a,:one,:bar] => @vector_arry1,
+          [:a,:two,:baz] => @vector_arry2,
+          [:b,:one,:foo] => @vector_arry1,
           [:b,:two,:foo] => @vector_arry2
           }, order: @order_mi, index: @multi_index)
 
         expect(df.index)               .to eq(@multi_index)
         expect(df.vectors)             .to eq(@order_mi)
-        expect(df[:a,:one,:bar]).to eq(Daru::Vector.new(@vector_arry1, 
+        expect(df[:a,:one,:bar]).to eq(Daru::Vector.new(@vector_arry1,
           index: @multi_index))
       end
 
@@ -340,12 +340,12 @@ describe Daru::DataFrame do
       end
 
       it "creates from Array of Arrays" do
-        df = Daru::DataFrame.new([@vector_arry1, @vector_arry2, @vector_arry1, 
+        df = Daru::DataFrame.new([@vector_arry1, @vector_arry2, @vector_arry1,
           @vector_arry2], index: @multi_index, order: @order_mi)
 
         expect(df.index)  .to eq(@multi_index)
         expect(df.vectors).to eq(@order_mi)
-        expect(df[:a, :one, :bar]).to eq(Daru::Vector.new(@vector_arry1, 
+        expect(df[:a, :one, :bar]).to eq(Daru::Vector.new(@vector_arry1,
           index: @multi_index))
       end
 
@@ -366,9 +366,9 @@ describe Daru::DataFrame do
           [:a,:one,:baz]
         ])
         mi_sorted = Daru::MultiIndex.from_tuples([
-          [:a, :one, :bar], 
-          [:a, :one, :baz], 
-          [:b, :one, :foo], 
+          [:a, :one, :bar],
+          [:a, :one, :baz],
+          [:b, :one, :foo],
           [:b, :two, :foo]
         ])
         order = Daru::MultiIndex.from_tuples([
@@ -398,8 +398,8 @@ describe Daru::DataFrame do
   context "#[]" do
     context Daru::Index do
       before :each do
-        @df = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5], 
-          c: [11,22,33,44,55]}, order: [:a, :b, :c], 
+        @df = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5],
+          c: [11,22,33,44,55]}, order: [:a, :b, :c],
           index: [:one, :two, :three, :four, :five])
       end
 
@@ -408,12 +408,12 @@ describe Daru::DataFrame do
       end
 
       it "returns a Vector by default" do
-        expect(@df[:a]).to eq(Daru::Vector.new([1,2,3,4,5], name: :a, 
+        expect(@df[:a]).to eq(Daru::Vector.new([1,2,3,4,5], name: :a,
           index: [:one, :two, :three, :four, :five]))
       end
 
       it "returns a DataFrame" do
-        temp = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5]}, 
+        temp = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5]},
           order: [:a, :b], index: [:one, :two, :three, :four, :five])
 
         expect(@df[:a, :b]).to eq(temp)
@@ -464,17 +464,17 @@ describe Daru::DataFrame do
   context "#[]=" do
     context Daru::Index do
       before :each do
-        @df = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5], 
-          c: [11,22,33,44,55]}, order: [:a, :b, :c], 
+        @df = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5],
+          c: [11,22,33,44,55]}, order: [:a, :b, :c],
           index: [:one, :two, :three, :four, :five])
       end
 
       it "assigns directly with the []= operator" do
         @data_frame[:a] = [100,200,300,400,500]
         expect(@data_frame).to eq(Daru::DataFrame.new({
-          b: [11,12,13,14,15], 
-          a: [100,200,300,400,500], 
-          c: [11,22,33,44,55]}, order: [:a, :b, :c], 
+          b: [11,12,13,14,15],
+          a: [100,200,300,400,500],
+          c: [11,22,33,44,55]}, order: [:a, :b, :c],
           index: [:one, :two, :three, :four, :five]))
       end
 
@@ -500,12 +500,12 @@ describe Daru::DataFrame do
         @df[:woo] = [69,99,108,85,49]
 
         expect(@df.woo.index).to eq([:one, :two, :three, :four, :five].to_index)
-      end   
+      end
 
       it "matches index of vector to be inserted with the DataFrame index" do
         @df[:shankar] = [69,99,108,85,49].dv(:shankar, [:two, :one, :three, :five, :four])
 
-        expect(@df.shankar).to eq([99,69,108,49,85].dv(:shankar, 
+        expect(@df.shankar).to eq([99,69,108,49,85].dv(:shankar,
           [:one, :two, :three, :four, :five]))
       end
 
@@ -535,12 +535,12 @@ describe Daru::DataFrame do
 
       it "assigns all sub-indexes when a top level index is specified" do
         @df_mi[:a] = [100,200,300,400,100,200,300,400,100,200,300,400]
-        
+
         expect(@df_mi).to eq(Daru::DataFrame.new([
           [100,200,300,400,100,200,300,400,100,200,300,400],
           [100,200,300,400,100,200,300,400,100,200,300,400],
           @vector_arry1,
-          @vector_arry2], index: @multi_index, order: @order_mi))  
+          @vector_arry2], index: @multi_index, order: @order_mi))
       end
 
       it "creates a new vector when full index specfied" do
@@ -551,7 +551,7 @@ describe Daru::DataFrame do
           [:b,:one,:foo],
           [:c,:one,:bar]])
         answer = Daru::DataFrame.new([
-          @vector_arry1, 
+          @vector_arry1,
           @vector_arry2,
           @vector_arry1,
           @vector_arry2,
@@ -567,8 +567,8 @@ describe Daru::DataFrame do
   context "#row[]=" do
     context Daru::Index do
       before :each do
-        @df = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5], 
-          c: [11,22,33,44,55]}, order: [:a, :b, :c], 
+        @df = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5],
+          c: [11,22,33,44,55]}, order: [:a, :b, :c],
           index: [:one, :two, :three, :four, :five])
       end
 
@@ -612,7 +612,7 @@ describe Daru::DataFrame do
 
       it "correctly aligns assigned DV by index" do
         @df.row[:two] = [9,2,11].dv(nil, [:b, :a, :c])
-        
+
         expect(@df.row[:two]).to eq([2,9,11].dv(:two, [:a, :b, :c]))
       end
 
@@ -649,8 +649,8 @@ describe Daru::DataFrame do
   context "#row" do
     context Daru::Index do
       before :each do
-        @df = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5], 
-          c: [11,22,33,44,55]}, order: [:a, :b, :c], 
+        @df = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5],
+          c: [11,22,33,44,55]}, order: [:a, :b, :c],
           index: [:one, :two, :three, :four, :five])
       end
 
@@ -664,16 +664,16 @@ describe Daru::DataFrame do
 
       it "returns a DataFrame when specifying numeric Range" do
         expect(@df.row[0..2]).to eq(
-          Daru::DataFrame.new({b: [11,12,13], a: [1,2,3], 
-            c: [11,22,33]}, order: [:a, :b, :c], 
+          Daru::DataFrame.new({b: [11,12,13], a: [1,2,3],
+            c: [11,22,33]}, order: [:a, :b, :c],
             index: [:one, :two, :three])
           )
       end
 
       it "returns a DataFrame when specifying symbolic Range" do
         expect(@df.row[:one..:three]).to eq(
-          Daru::DataFrame.new({b: [11,12,13], a: [1,2,3], 
-            c: [11,22,33]}, order: [:a, :b, :c], 
+          Daru::DataFrame.new({b: [11,12,13], a: [1,2,3],
+            c: [11,22,33]}, order: [:a, :b, :c],
             index: [:one, :two, :three])
           )
       end
@@ -687,11 +687,11 @@ describe Daru::DataFrame do
       end
 
       it "returns a row with given Integer index for default index-less DataFrame" do
-        df = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5], 
+        df = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5],
           c: [11,22,33,44,55]}, order: [:a, :b, :c])
 
         expect(df.row[0]).to eq([1,11,11].dv(nil, [:a, :b, :c]))
-      end    
+      end
     end
 
     context Daru::MultiIndex do
@@ -762,10 +762,10 @@ describe Daru::DataFrame do
 
   context "#==" do
     it "compares by vectors, index and values of a DataFrame (ignores name)" do
-      a = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5]}, 
+      a = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5]},
         order: [:a, :b], index: [:one, :two, :three, :four, :five])
 
-      b = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5]}, 
+      b = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5]},
         order: [:a, :b], index: [:one, :two, :three, :four, :five])
 
       expect(a).to eq(b)
@@ -778,11 +778,12 @@ describe Daru::DataFrame do
         clo = @data_frame.dup
 
         expect(clo.object_id)        .not_to eq(@data_frame.object_id)
-        expect(clo.vectors.object_id).not_to eq(@data_frame.object_id)
-        expect(clo.index.object_id)  .not_to eq(@data_frame.object_id)
+        expect(clo.vectors.object_id).not_to eq(@data_frame.vectors.object_id)
+        expect(clo.index.object_id)  .not_to eq(@data_frame.index.object_id)
 
         @data_frame.each_vector_with_index do |vector, index|
           expect(vector.object_id).not_to eq(clo[index].object_id)
+          expect(vector.to_a.object_id).not_to eq(clo[index].to_a.object_id)
         end
       end
     end
@@ -804,7 +805,7 @@ describe Daru::DataFrame do
         a: [1  , 2, 3, nil, 4, nil, 5],
         b: [nil, 2, 3, nil, 4, nil, 5],
         c: [1,   2, 3, 43 , 4, nil, 5]
-      })      
+      })
     end
 
     it "dups rows with non-missing data only" do
@@ -812,7 +813,7 @@ describe Daru::DataFrame do
         a: [2, 3, 4, 5],
         b: [2, 3, 4, 5],
         c: [2, 3, 4, 5]
-      }, index: [1,2,4,6]) 
+      }, index: [1,2,4,6])
       expect(@missing_data_df.dup_only_valid).to eq(df)
     end
 
@@ -865,7 +866,7 @@ describe Daru::DataFrame do
       ret = @data_frame.each_vector_with_index do |vector, index|
         idxs << index
         expect(vector.index).to eq([:one, :two, :three, :four, :five].to_index)
-        expect(vector.class).to eq(Daru::Vector) 
+        expect(vector.class).to eq(Daru::Vector)
       end
 
       expect(idxs).to eq([:a, :b, :c])
@@ -901,7 +902,7 @@ describe Daru::DataFrame do
     it "iterates over all vectors" do
       ret = @data_frame.each do |vector|
         expect(vector.index).to eq([:one, :two, :three, :four, :five].to_index)
-        expect(vector.class).to eq(Daru::Vector) 
+        expect(vector.class).to eq(Daru::Vector)
       end
 
       expect(ret).to eq(@data_frame)
@@ -909,18 +910,18 @@ describe Daru::DataFrame do
 
     it "returns Enumerable if no block specified" do
       ret = @data_frame.each
-      expect(ret.is_a?(Enumerator)).to eq(true) 
+      expect(ret.is_a?(Enumerator)).to eq(true)
     end
   end
 
   context "#recode" do
     before do
-      @ans_vector = Daru::DataFrame.new({b: [21,22,23,24,25], a: [11,12,13,14,15], 
-        c: [21,32,43,54,65]}, order: [:a, :b, :c], 
+      @ans_vector = Daru::DataFrame.new({b: [21,22,23,24,25], a: [11,12,13,14,15],
+        c: [21,32,43,54,65]}, order: [:a, :b, :c],
         index: [:one, :two, :three, :four, :five])
 
-      @ans_rows = Daru::DataFrame.new({b: [121, 144, 169, 196, 225], a: [1,4,9,16,25], 
-        c: [121, 484, 1089, 1936, 3025]}, order: [:a, :b, :c], 
+      @ans_rows = Daru::DataFrame.new({b: [121, 144, 169, 196, 225], a: [1,4,9,16,25],
+        c: [121, 484, 1089, 1936, 3025]}, order: [:a, :b, :c],
         index: [:one, :two, :three, :four, :five])
     end
 
@@ -945,7 +946,7 @@ describe Daru::DataFrame do
   context "#collect" do
     before do
       @df = Daru::DataFrame.new({
-        a: [1,2,3,4,5], 
+        a: [1,2,3,4,5],
         b: [11,22,33,44,55],
         c: [1,2,3,4,5]
       })
@@ -985,12 +986,12 @@ describe Daru::DataFrame do
 
   context "#map!" do
     before do
-      @ans_vector = Daru::DataFrame.new({b: [21,22,23,24,25], a: [11,12,13,14,15], 
-        c: [21,32,43,54,65]}, order: [:a, :b, :c], 
+      @ans_vector = Daru::DataFrame.new({b: [21,22,23,24,25], a: [11,12,13,14,15],
+        c: [21,32,43,54,65]}, order: [:a, :b, :c],
         index: [:one, :two, :three, :four, :five])
 
-      @ans_row = Daru::DataFrame.new({b: [12,13,14,15,16], a: [2,3,4,5,6], 
-        c: [12,23,34,45,56]}, order: [:a, :b, :c], 
+      @ans_row = Daru::DataFrame.new({b: [12,13,14,15,16], a: [2,3,4,5,6],
+        c: [12,23,34,45,56]}, order: [:a, :b, :c],
         index: [:one, :two, :three, :four, :five])
     end
 
@@ -1020,7 +1021,7 @@ describe Daru::DataFrame do
 
       expect(ret).to eq([
         Daru::Vector.new([11,12,13,14,15],index: [:one, :two, :three, :four, :five]),
-        Daru::Vector.new([21,22,23,24,25],index: [:one, :two, :three, :four, :five]), 
+        Daru::Vector.new([21,22,23,24,25],index: [:one, :two, :three, :four, :five]),
         Daru::Vector.new([21,32,43,54,65],index: [:one, :two, :three, :four, :five])])
       expect(idx).to eq([:a, :b, :c])
     end
@@ -1045,9 +1046,9 @@ describe Daru::DataFrame do
       it "deletes the specified vector" do
         @data_frame.delete_vector :a
 
-        expect(@data_frame).to eq(Daru::DataFrame.new({b: [11,12,13,14,15], 
-                c: [11,22,33,44,55]}, order: [:b, :c], 
-                index: [:one, :two, :three, :four, :five]))    
+        expect(@data_frame).to eq(Daru::DataFrame.new({b: [11,12,13,14,15],
+                c: [11,22,33,44,55]}, order: [:b, :c],
+                index: [:one, :two, :three, :four, :five]))
       end
     end
   end
@@ -1056,7 +1057,7 @@ describe Daru::DataFrame do
     it "deletes the specified row" do
       @data_frame.delete_row :three
 
-      expect(@data_frame).to eq(Daru::DataFrame.new({b: [11,12,14,15], a: [1,2,4,5], 
+      expect(@data_frame).to eq(Daru::DataFrame.new({b: [11,12,14,15], a: [1,2,4,5],
       c: [11,22,44,55]}, order: [:a, :b, :c], index: [:one, :two, :four, :five]))
     end
   end
@@ -1064,8 +1065,8 @@ describe Daru::DataFrame do
   context "#keep_row_if" do
     pending "changing row from under the iterator trips this"
     it "keeps row if block evaluates to true" do
-      df = Daru::DataFrame.new({b: [10,12,20,23,30], a: [50,30,30,1,5], 
-        c: [10,20,30,40,50]}, order: [:a, :b, :c], 
+      df = Daru::DataFrame.new({b: [10,12,20,23,30], a: [50,30,30,1,5],
+        c: [10,20,30,40,50]}, order: [:a, :b, :c],
         index: [:one, :two, :three, :four, :five])
 
       df.keep_row_if do |row|
@@ -1081,16 +1082,16 @@ describe Daru::DataFrame do
         vector == [1,2,3,4,5].dv(nil, [:one, :two, :three, :four, :five])
       end
 
-      expect(@data_frame).to eq(Daru::DataFrame.new({a: [1,2,3,4,5]}, order: [:a], 
+      expect(@data_frame).to eq(Daru::DataFrame.new({a: [1,2,3,4,5]}, order: [:a],
         index: [:one, :two, :three, :four, :five]))
     end
   end
 
   context "#filter_field" do
     before do
-      @df = Daru::DataFrame.new({ 
-        :id => Daru::Vector.new([1, 2, 3, 4, 5]), 
-        :name => Daru::Vector.new(%w(Alex Claude Peter Franz George)), 
+      @df = Daru::DataFrame.new({
+        :id => Daru::Vector.new([1, 2, 3, 4, 5]),
+        :name => Daru::Vector.new(%w(Alex Claude Peter Franz George)),
         :age => Daru::Vector.new([20, 23, 25, 27, 5]),
         :city => Daru::Vector.new(['New York', 'London', 'London', 'Paris', 'Tome']),
         :a1 => Daru::Vector.new(['a,b', 'b,c', 'a', nil, 'a,b,c']) },
@@ -1139,10 +1140,10 @@ describe Daru::DataFrame do
         expect(arry).to eq(
           [
             [
-              {a: 1, b: 11, c: 11}, 
+              {a: 1, b: 11, c: 11},
               {a: 2, b: 12, c: 22},
               {a: 3, b: 13, c: 33},
-              {a: 4, b: 14, c: 44}, 
+              {a: 4, b: 14, c: 44},
               {a: 5, b: 15, c: 55}
             ],
             [
@@ -1159,13 +1160,13 @@ describe Daru::DataFrame do
 
   context "#to_hash" do
     it "converts to a hash" do
-      expect(@data_frame.to_hash).to eq( 
+      expect(@data_frame.to_hash).to eq(
         {
-          a: Daru::Vector.new([1,2,3,4,5], 
-            index: [:one, :two, :three, :four, :five]), 
-          b: Daru::Vector.new([11,12,13,14,15], 
+          a: Daru::Vector.new([1,2,3,4,5],
             index: [:one, :two, :three, :four, :five]),
-          c: Daru::Vector.new([11,22,33,44,55], 
+          b: Daru::Vector.new([11,12,13,14,15],
+            index: [:one, :two, :three, :four, :five]),
+          c: Daru::Vector.new([11,22,33,44,55],
             index: [:one, :two, :three, :four, :five])
         }
       )
@@ -1193,7 +1194,7 @@ describe Daru::DataFrame do
         ans = @df.sort([:a], by: { a: a_sorter })
 
         expect(ans).to eq(
-          Daru::DataFrame.new({a: [-6,1,5,5,5,7], b: [5,-1,9,1,-2,3], c: ['aaa','aa','aaaaa','aaaaaa','a','aaaa']}, 
+          Daru::DataFrame.new({a: [-6,1,5,5,5,7], b: [5,-1,9,1,-2,3], c: ['aaa','aa','aaaaa','aaaaaa','a','aaaa']},
             index: [2,1,4,5,0,3])
           )
         expect(ans).to_not eq(@df)
@@ -1206,9 +1207,9 @@ describe Daru::DataFrame do
             index: [2,1,0,5,4,3])
           )
         expect(ans).to_not eq(@df)
-      end  
+      end
     end
-    
+
     context Daru::MultiIndex do
       pending
     end
@@ -1217,7 +1218,7 @@ describe Daru::DataFrame do
   context "#sort!" do
     context Daru::Index do
       before :each do
-        @df = Daru::DataFrame.new({a: [5,1,-6,7,5,5], b: [-2,-1,5,3,9,1], 
+        @df = Daru::DataFrame.new({a: [5,1,-6,7,5,5], b: [-2,-1,5,3,9,1],
           c: ['a','aa','aaa','aaaa','aaaaa','aaaaaa']})
       end
 
@@ -1225,7 +1226,7 @@ describe Daru::DataFrame do
         a_sorter = lambda { |a,b| a <=> b }
 
         expect(@df.sort!([:a], by: { a: a_sorter })).to eq(
-          Daru::DataFrame.new({a: [-6,1,5,5,5,7], b: [5,-1,9,1,-2,3], 
+          Daru::DataFrame.new({a: [-6,1,5,5,5,7], b: [5,-1,9,1,-2,3],
             c: ['aaa','aa','aaaaa','aaaaaa','a','aaaa']}, index: [2,1,4,5,0,3])
           )
       end
@@ -1253,14 +1254,14 @@ describe Daru::DataFrame do
 
       it "sorts many vectors" do
         d = Daru::DataFrame.new({a: [1,1,1,222,44,5,5,544], b: [44,44,333,222,111,554,22,3], c: [3,2,5,3,3,1,5,5]})
-        
+
         expect(d.sort!([:a, :b, :c], ascending: [false, true, false])).to eq(
           Daru::DataFrame.new({a: [544,222,44,5,5,1,1,1], b: [3,222,111,22,554,44,44,333], c: [5,3,3,5,1,3,2,5]},
             index: [7,3,4,6,5,0,1,2])
           )
       end
     end
-    
+
     context Daru::MultiIndex do
       pending
       it "sorts the DataFrame when specified full tuple" do
@@ -1322,7 +1323,7 @@ describe Daru::DataFrame do
         b: [11,22,33,44,55],
         c: %w(a b c d e)
       })
-      
+
       ans = df.reindex(Daru::Index.new([1,3,0,8,2]))
       expect(ans).to eq(Daru::DataFrame.new({
         a: [2,4,1,nil,3],
@@ -1352,9 +1353,9 @@ describe Daru::DataFrame do
 
   context "#to_matrix" do
     before do
-      @df = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5], 
-        c: [11,22,33,44,55], d: [5,4,nil,2,1], e: ['this', 'has', 'string','data','too']}, 
-        order: [:a, :b, :c,:d,:e], 
+      @df = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5],
+        c: [11,22,33,44,55], d: [5,4,nil,2,1], e: ['this', 'has', 'string','data','too']},
+        order: [:a, :b, :c,:d,:e],
         index: [:one, :two, :three, :four, :five])
     end
 
@@ -1371,9 +1372,9 @@ describe Daru::DataFrame do
 
   context "#to_nmatrix" do
     before do
-      @df = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5], 
-        c: [11,22,33,44,55], d: [5,4,nil,2,1], e: ['this', 'has', 'string','data','too']}, 
-        order: [:a, :b, :c,:d,:e], 
+      @df = Daru::DataFrame.new({b: [11,12,13,14,15], a: [1,2,3,4,5],
+        c: [11,22,33,44,55], d: [5,4,nil,2,1], e: ['this', 'has', 'string','data','too']},
+        order: [:a, :b, :c,:d,:e],
         index: [:one, :two, :three, :four, :five])
     end
 
@@ -1383,7 +1384,7 @@ describe Daru::DataFrame do
          2,12,22,
          3,13,33,
          4,14,44,
-         5,15,55] 
+         5,15,55]
       ))
     end
   end
@@ -1392,10 +1393,10 @@ describe Daru::DataFrame do
     context Daru::Index do
       it "transposes a DataFrame including row and column indexing" do
         expect(@data_frame.transpose).to eq(Daru::DataFrame.new({
-          one: [1,11,11], 
-          two: [2,12,22], 
-          three: [3,13,33], 
-          four: [4,14,44], 
+          one: [1,11,11],
+          two: [2,12,22],
+          three: [3,13,33],
+          four: [4,14,44],
           five: [5,15,55]
           }, index: [:a, :b, :c],
           order: [:one, :two, :three, :four, :five])
@@ -1406,9 +1407,9 @@ describe Daru::DataFrame do
     context Daru::MultiIndex do
       it "transposes a DataFrame including row and column indexing" do
         expect(@df_mi.transpose).to eq(Daru::DataFrame.new([
-          @vector_arry1, 
-          @vector_arry2, 
-          @vector_arry1, 
+          @vector_arry1,
+          @vector_arry2,
+          @vector_arry1,
           @vector_arry2].transpose, index: @order_mi, order: @multi_index))
       end
     end
@@ -1417,7 +1418,7 @@ describe Daru::DataFrame do
   context "#pivot_table" do
     before do
       @df = Daru::DataFrame.new({
-        a: ['foo'  ,  'foo',  'foo',  'foo',  'foo',  'bar',  'bar',  'bar',  'bar'], 
+        a: ['foo'  ,  'foo',  'foo',  'foo',  'foo',  'bar',  'bar',  'bar',  'bar'],
         b: ['one'  ,  'one',  'one',  'two',  'two',  'one',  'one',  'two',  'two'],
         c: ['small','large','large','small','small','large','small','large','small'],
         d: [1,2,2,3,3,4,5,6,7],
@@ -1434,7 +1435,7 @@ describe Daru::DataFrame do
 
     it "creates row index as per (double) index argument and default aggregates to mean" do
       agg_mi = Daru::MultiIndex.from_tuples(
-        [        
+        [
           ['bar', 'large'],
           ['bar', 'small'],
           ['foo', 'large'],
@@ -1446,7 +1447,7 @@ describe Daru::DataFrame do
         e: [10.0, 12.0, 4.0, 4.67]
       }, index: agg_mi))
     end
- 
+
     it "creates row and vector index as per (single) index and (single) vectors args" do
       agg_vectors = Daru::MultiIndex.from_tuples([
         [:d, 'one'],
@@ -1460,7 +1461,7 @@ describe Daru::DataFrame do
           ['foo']
         ]
       )
-      
+
       expect(@df.pivot_table(index: [:a], vectors: [:b]).round(2)).to eq(
         Daru::DataFrame.new(
           [
@@ -1596,7 +1597,7 @@ describe Daru::DataFrame do
         df.pivot_table(index: [:a])
       }.to raise_error
     end
- 
+
     it "raises error if atleast a row index is not specified" do
       expect {
         @df.pivot_table
@@ -1630,7 +1631,7 @@ describe Daru::DataFrame do
       expect(@df_mi.summary.match("#{@df_mi.name}")).to_not eq(nil)
     end
   end
-  
+
   context "#to_gsl" do
     it "converts to GSL::Matrix" do
       rows = [[1,2,3,4,5],[11,12,13,14,15],[11,22,33,44,55]].transpose
@@ -1655,7 +1656,7 @@ describe Daru::DataFrame do
         Daru::DataFrame.new({c: c, d: d, a: a, b: b}, order: [:c, :d, :a, :b]))
 
       ds3 = Daru::DataFrame.new({ :a => e })
-      exp = Daru::DataFrame.new({ :a_1 => a, :a_2 => e, :b => b }, 
+      exp = Daru::DataFrame.new({ :a_1 => a, :a_2 => e, :b => b },
         order: [:a_1, :b, :a_2])
 
       expect(ds1.merge(ds3)).to eq(exp)
@@ -1703,7 +1704,7 @@ describe Daru::DataFrame do
       b1 = Daru::Vector.new [nil, nil, 1, 1, 1, 2]
       b2 = Daru::Vector.new [2, 2, 2, nil, 2, 3]
       c  = Daru::Vector.new [nil, 2, 4, 2, 2, 2]
-      df = Daru::DataFrame.new({ 
+      df = Daru::DataFrame.new({
         :a1 => a1, :a2 => a2, :b1 => b1, :b2 => b2, :c => c })
 
       expect(df.missing_values_rows).to eq(Daru::Vector.new [2, 3, 0, 1, 0, 1])
@@ -1763,12 +1764,12 @@ describe Daru::DataFrame do
 
   context "#add_vectors_by_split_recode" do
     before do
-      @ds = Daru::DataFrame.new({ 
-        :id   => Daru::Vector.new([1, 2, 3, 4, 5]), 
-        :name => Daru::Vector.new(%w(Alex Claude Peter Franz George)), 
+      @ds = Daru::DataFrame.new({
+        :id   => Daru::Vector.new([1, 2, 3, 4, 5]),
+        :name => Daru::Vector.new(%w(Alex Claude Peter Franz George)),
         :age  => Daru::Vector.new([20, 23, 25, 27, 5]),
         :city => Daru::Vector.new(['New York', 'London', 'London', 'Paris', 'Tome']),
-        :a1   => Daru::Vector.new(['a,b', 'b,c', 'a', nil, 'a,b,c']) }, 
+        :a1   => Daru::Vector.new(['a,b', 'b,c', 'a', nil, 'a,b,c']) },
         order: [:id, :name, :age, :city, :a1])
     end
 
@@ -1783,12 +1784,12 @@ describe Daru::DataFrame do
 
   context "#add_vectors_by_split" do
     before do
-      @ds = Daru::DataFrame.new({ 
-        :id   => Daru::Vector.new([1, 2, 3, 4, 5]), 
-        :name => Daru::Vector.new(%w(Alex Claude Peter Franz George)), 
+      @ds = Daru::DataFrame.new({
+        :id   => Daru::Vector.new([1, 2, 3, 4, 5]),
+        :name => Daru::Vector.new(%w(Alex Claude Peter Franz George)),
         :age  => Daru::Vector.new([20, 23, 25, 27, 5]),
         :city => Daru::Vector.new(['New York', 'London', 'London', 'Paris', 'Tome']),
-        :a1   => Daru::Vector.new(['a,b', 'b,c', 'a', nil, 'a,b,c']) 
+        :a1   => Daru::Vector.new(['a,b', 'b,c', 'a', nil, 'a,b,c'])
         }, order: [:id, :name, :age, :city, :a1])
     end
 
@@ -1814,14 +1815,14 @@ describe Daru::DataFrame do
       v2   = Daru::Vector.new [4, 3, 2, 1]
       v3   = Daru::Vector.new [10, 20, 30, 40]
       v4   = Daru::Vector.new %w(a b a b)
-      @df = Daru::DataFrame.new({ 
-        :v1 => v1, :v2 => v2, :v3 => v3, :v4 => v4, :id => name 
+      @df = Daru::DataFrame.new({
+        :v1 => v1, :v2 => v2, :v3 => v3, :v4 => v4, :id => name
         }, order: [:v1, :v2, :v3, :v4, :id])
     end
 
     it "correctly verifies data as per the block" do
       # Correct
-      t1 = create_test('If v4=a, v1 odd') do |r| 
+      t1 = create_test('If v4=a, v1 odd') do |r|
         r[:v4] == 'b' or (r[:v4] == 'a' and r[:v1].odd?)
       end
       t2 = create_test('v3=v1*10')  { |r| r[:v3] == r[:v1] * 10 }
@@ -1870,7 +1871,7 @@ describe Daru::DataFrame do
       ev_a  = Daru::Vector.new [0, 0, 0]
       ev_b  = Daru::Vector.new [1, 1, 0]
       ev_c  = Daru::Vector.new [0, 1, 1]
-      df2 = Daru::DataFrame.new({ 
+      df2 = Daru::DataFrame.new({
         :_id => ev_id, 'a' => ev_a, 'b' => ev_b, 'c' => ev_c })
 
       expect(df2).to eq(df)
@@ -1885,8 +1886,8 @@ describe Daru::DataFrame do
         ['3', 'alfred', nil, nil, nil, nil, nil, nil]
       ]
 
-      df = Daru::DataFrame.rows(rows, 
-        order: ['id', 'name', 'car_color1', 'car_value1', 'car_color2', 
+      df = Daru::DataFrame.rows(rows,
+        order: ['id', 'name', 'car_color1', 'car_value1', 'car_color2',
           'car_value2', 'car_color3', 'car_value3'])
 
       ids     = Daru::Vector.new %w(1 1 2 2 2)
@@ -1905,7 +1906,7 @@ describe Daru::DataFrame do
   context "#any?" do
     before do
       @df = Daru::DataFrame.new({
-        a: [1,2,3,4,5], 
+        a: [1,2,3,4,5],
         b: [10,20,30,40,50],
         c: [11,22,33,44,55]})
     end
@@ -1930,11 +1931,11 @@ describe Daru::DataFrame do
   context "#all?" do
     before do
       @df = Daru::DataFrame.new({
-        a: [1,2,3,4,5], 
+        a: [1,2,3,4,5],
         b: [10,20,30,40,50],
         c: [11,22,33,44,55]})
     end
-    
+
     it "returns true if all of the vectors satisfy condition" do
       expect(@df.all? { |v| v.mean < 40 }).to eq(true)
     end


### PR DESCRIPTION
Prior to this fix, if a dataframe was duplicated and a vector of the duplicated
dataframe was destructively recoded, the original dataframe would
also have a modified vector.

Resolves #36 