### PR TITLE
Tune up sort [amendment]

### DIFF
--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -545,9 +545,9 @@ module Daru
         if av.nil? && bv.nil?
           ai <=> bi
         elsif av.nil?
-          -1
+          opts[:ascending]? -1:1
         else
-          1
+          opts[:ascending]? 1:-1
         end
       } unless block      
 

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -502,11 +502,32 @@ describe Daru::Vector do
             expect(sorted).to eq(Daru::Vector.new(["My", "Jazz", "Guitar", "My Jazz Guitar"], index: [2,1,3,0]))
           end
 
-          it "places nils near the beginning of the vector" do
+          it "places nils near the beginning of the vector when sorting ascendingly" do
             with_nils = Daru::Vector.new [22,4,nil,111,nil,2]
 
             expect(with_nils.sort).to eq(Daru::Vector.new([nil,nil,2,4,22,111], index: [2,4,5,1,0,3]))
           end if dtype == :array
+
+          it "places nils near the beginning of the vector when sorting descendingly" do
+            with_nils = Daru::Vector.new [22,4,nil,111,nil,2]
+
+            expect(with_nils.sort(ascending: false)).to eq(
+              Daru::Vector.new [nil,nil,111,22,4,2], index: [4,2,3,0,1,5])
+          end
+
+          it "correctly sorts vector in ascending order with non-numeric data and nils" do
+            non_numeric = Daru::Vector.new ['a','b', nil, 'aa', '1234', nil]
+
+            expect(non_numeric.sort(ascending: true)).to eq(
+              Daru::Vector.new [nil,nil,'1234','a','aa','b'], index: [2,5,4,0,3,1])
+          end
+
+          it "correctly sorts vector in descending order with non-numeric data and nils" do
+            non_numeric = Daru::Vector.new ['a','b', nil, 'aa', '1234', nil]
+
+            expect(non_numeric.sort(ascending: false)).to eq(
+              Daru::Vector.new [nil,nil,'b','aa','a','1234'], index: [5,2,1,3,0,4])
+          end
         end
 
         context Daru::MultiIndex do


### PR DESCRIPTION
Amendment to #63 

- Places nils at top when descending
- Add relevant tests to check nils ordering with numeric and non-numeric data