### PR TITLE
Massive performance enhancement for joins.

### DIFF
--- a/benchmarks/joining.rb
+++ b/benchmarks/joining.rb
@@ -1,0 +1,52 @@
+$:.unshift File.expand_path("../../lib", __FILE__)
+
+require 'benchmark'
+require 'daru'
+
+# Check scaling
+base_n = 10000
+0.upto(2) do |iscale|
+  n = base_n * 2**iscale
+  keys = (1..(n)).to_a
+  base_data = { idx: 1.upto(n).to_a, keys: 1.upto(n).map { |v| keys[Random.rand(n)]}}
+  lookup_hash = keys.map { |k| [k, k * 100]}.to_h
+
+  base_data_df = Daru::DataFrame.new(base_data)
+  lookup_df = Daru::DataFrame.new({ keys: lookup_hash.keys, values: lookup_hash.values })
+
+  Benchmark.bm do |bm|
+    bm.report("Inner join (n=#{n})") do
+      base_data_df.join(lookup_df, on: [:keys], how: :inner)
+    end
+
+    bm.report("Outer join (n=#{n})") do
+      base_data_df.join(lookup_df, on: [:keys], how: :outer)
+    end
+  end
+end
+
+#                   ===== Benchmarks =====
+# System: MacBook Pro Mid 2014 3GHz Core i7
+#
+#       user     system      total        real
+#Inner join (n=10000)  0.170000   0.000000   0.170000 (  0.182254)
+#Outer join (n=10000)  0.200000   0.000000   0.200000 (  0.203022)
+#       user     system      total        real
+#Inner join (n=20000)  0.380000   0.000000   0.380000 (  0.387600)
+#Outer join (n=20000)  0.410000   0.000000   0.410000 (  0.415644)
+#       user     system      total        real
+#Inner join (n=40000)  0.720000   0.010000   0.730000 (  0.743787)
+#Outer join (n=40000)  0.810000   0.010000   0.820000 (  0.840871)
+
+
+#                   ===== Prior Benchmarks (Daru 0.1.2 - prior to sorted merge algorithm) =====
+# Note that the n here is 10x smaller than above
+#       user     system      total        real
+#Inner join (n=1000)  0.170000   0.010000   0.180000 (  0.175585)
+#Outer join (n=1000)  0.990000   0.000000   0.990000 (  1.004305)
+#       user     system      total        real
+#Inner join (n=2000)  0.440000   0.010000   0.450000 (  0.446748)
+#Outer join (n=2000)  3.880000   0.010000   3.890000 (  3.926399)
+#       user     system      total        real
+#Inner join (n=4000)  1.670000   0.010000   1.680000 (  1.680742)
+#Outer join (n=4000) 15.640000   0.060000  15.700000 ( 15.855202)

--- a/daru.gemspec
+++ b/daru.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 *************************************************************************
 Thank you for installing daru!
 
-  oOOOOOo 
+  oOOOOOo
  ,|    oO
 //|     |
 \\\\|     |
@@ -39,8 +39,8 @@ Thank you for installing daru!
   `-----`
 
 
-Hope you love daru! For enhanced interactivity and better visualizations, 
-consider using gnuplotrb and nyaplot with iruby. For statistics use the 
+Hope you love daru! For enhanced interactivity and better visualizations,
+consider using gnuplotrb and nyaplot with iruby. For statistics use the
 statsample family.
 
 Read the README for interesting use cases and examples.
@@ -63,7 +63,6 @@ EOF
   spec.add_development_dependency 'nmatrix', '~> 0.2.1'
   spec.add_development_dependency 'distribution', '~> 0.7'
   spec.add_development_dependency 'rb-gsl', '~>1.16'
-  spec.add_development_dependency 'bloomfilter-rb', '~> 2.1'
   spec.add_development_dependency 'dbd-sqlite3'
   spec.add_development_dependency 'dbi'
   spec.add_development_dependency 'activerecord', '~> 4.0'

--- a/lib/daru.rb
+++ b/lib/daru.rb
@@ -27,16 +27,16 @@ module Daru
     11 => 30,
     12 => 31
   }
-  
+
   SPLIT_TOKEN = ','
   class << self
     @@lazy_update = false
-    
+
     # A variable which will set whether Vector metadata is updated immediately or lazily.
     # Call the #update method every time a values are set or removed in order to update
     # metadata like positions of missing values.
     attr_accessor :lazy_update
-    
+
     def create_has_library(library)
       lib_underscore = library.to_s.gsub(/-/, '_')
       define_singleton_method("has_#{lib_underscore}?") do
@@ -58,7 +58,6 @@ module Daru
   create_has_library :gsl
   create_has_library :nmatrix
   create_has_library :nyaplot
-  create_has_library :'bloomfilter-rb'
 end
 
 autoload :Spreadsheet, 'spreadsheet'

--- a/lib/daru/monkeys.rb
+++ b/lib/daru/monkeys.rb
@@ -34,7 +34,7 @@ class Array
       self
     end
   end
-  
+
   def daru_vector name=nil, index=nil, dtype=:array
     Daru::Vector.new self, name: name, index: index, dtype: dtype
   end

--- a/spec/core/merge_spec.rb
+++ b/spec/core/merge_spec.rb
@@ -19,45 +19,45 @@ describe Daru::DataFrame do
 
     it "performs an inner join of two dataframes" do
       answer = Daru::DataFrame.new({
-        :id_1   => [1,3],
-        :name => ['Pirate', 'Ninja'],
-        :id_2   => [2,4]
+        :id_1   => [3,1],
+        :name => ['Ninja', 'Pirate'],
+        :id_2   => [4,2]
       }, order: [:id_1, :name, :id_2])
       expect(@left.join(@right, how: :inner, on: [:name])).to eq(answer)
     end
 
     it "performs an inner join of two dataframes that has one to many mapping" do
       answer = Daru::DataFrame.new({
-        :id => [1,1,1,1],
         :name_1 => ['Pirate', 'Pirate', 'Pirate', 'Pirate'],
+        :id => [1,1,1,1],
         :name_2 => ['Rutabaga', 'Pirate', 'Darth Vader', 'Ninja']
-      }, order: [:id, :name_1, :name_2])
+      }, order: [:name_1, :id, :name_2])
       expect(@left.join(@right_many, how: :inner, on: [:id])).to eq(answer)
     end
 
     it "performs a full outer join" do
       answer = Daru::DataFrame.new({
-        :id_1 => [1,2,3,4,nil,nil],
-        :name => ['Pirate', 'Monkey', 'Ninja', 'Spaghetti','Rutabaga', 'Darth Vader'],
-        :id_2 => [2,nil,4,nil,1,3]
+        :id_1 => [nil,2,3,1,nil,4],
+        :name => ["Darth Vader", "Monkey", "Ninja", "Pirate", "Rutabaga", "Spaghetti"],
+        :id_2 => [3,nil,4,2,1,nil]
       }, order: [:id_1, :name, :id_2])
       expect(@left.join(@right, how: :outer, on: [:name])).to eq(answer)
     end
 
     it "performs a left outer join", focus: true do
       answer = Daru::DataFrame.new({
-        :id_1 => [1,2,3,4],
-        :name => ['Pirate', 'Monkey', 'Ninja', 'Spaghetti'],
-        :id_2 => [2,nil,4,nil]
+        :id_1 => [2,3,1,4],
+        :name => ["Monkey", "Ninja", "Pirate", "Spaghetti"],
+        :id_2 => [nil,4,2,nil]
       }, order: [:id_1, :name, :id_2])
       expect(@left.join(@right, how: :left, on: [:name])).to eq(answer)
     end
 
     it "performs a right outer join" do
       answer = Daru::DataFrame.new({
-        :id_1 => [nil,1,nil,3],
-        :name => ['Rutabaga','Pirate', 'Darth Vader', 'Ninja'],
-        :id_2 => [1,2,3,4]
+        :id_1 => [nil,3,1,nil],
+        :name => ["Darth Vader", "Ninja", "Pirate", "Rutabaga"],
+        :id_2 => [3,4,2,1]
       }, order: [:id_1, :name, :id_2])
       expect(@left.join(@right, how: :right, on: [:name])).to eq(answer)
     end


### PR DESCRIPTION
This commit replaces the previous cartesian and bloomfilter
algorithms for joining with a sorted merge method.  The
result is that joins are now O(n) instead of O(n^2).

Check benchmarks/joining.rb for details on performance enhancement.
