### PR TITLE
FIX - Bug with handling nils in the group-by keys.

### DIFF
--- a/lib/daru/core/group_by.rb
+++ b/lib/daru/core/group_by.rb
@@ -263,7 +263,7 @@ module Daru
       end
 
       def multi_indexed_grouping?
-        @groups.keys[0][1] ? true : false
+        @groups.keys[0].size > 1 ? true : false
       end
     end
   end

--- a/spec/core/group_by_spec.rb
+++ b/spec/core/group_by_spec.rb
@@ -41,6 +41,10 @@ describe Daru::Core::GroupBy do
     it 'groups by nil values' do
       expect(@df.group_by(:w_nils).groups[[nil]]).to eq([1,3,4])
     end
+
+    it "uses a multi-index when nils are part of the grouping keys" do
+      expect(@df.group_by(:a, :w_nils).send(:multi_indexed_grouping?)).to be true
+    end
   end
 
   context "#initialize" do


### PR DESCRIPTION
This commit resolves an issue discovered when grouping by keys that
may involves nil values.   When `@groups.keys[0][1]` happens to be
a nil value for a key, then multi_indexed_grouping? would return false,
even though it should have returned true.  This commit changes
the test to check the size of grouping keys.