### PR TITLE
Fixes in MultiIndex to raise error on accessing invalid index

### DIFF
--- a/lib/daru/index.rb
+++ b/lib/daru/index.rb
@@ -253,6 +253,7 @@ module Daru
 
       key.each_with_index do |k, depth|
         level_index = @levels[depth][k]
+        raise IndexError, "Specified index #{key.inspect} do not exist" if level_index.nil?
         label = @labels[depth]
         chosen = find_all_indexes label, level_index, chosen
       end

--- a/lib/daru/index.rb
+++ b/lib/daru/index.rb
@@ -197,7 +197,6 @@ module Daru
     def incorrect_fields? labels, levels
       max_level = levels[0].size
 
-      correct = labels.all? { |e| e.size == max_level }
       correct = levels.all? { |e| e.uniq.size == e.size }
 
       !correct

--- a/spec/index_spec.rb
+++ b/spec/index_spec.rb
@@ -203,6 +203,14 @@ describe Daru::MultiIndex do
         [:b,:two,:baz]
       ]))
     end
+    
+    it "raises error when specifying invalid index" do
+      expect { @multi_mi[:a, :three] }.to raise_error IndexError
+      expect { @multi_mi[:a, :one, :xyz] }.to raise_error IndexError
+      expect { @multi_mi[:x] }.to raise_error IndexError
+      expect { @multi_mi[:x, :one] }.to raise_error IndexError
+      expect { @multi_mi[:x, :one, :bar] }.to raise_error IndexError
+    end
 
     it "works with numerical first levels" do
       mi = Daru::MultiIndex.from_tuples([

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -240,6 +240,7 @@ describe Daru::Vector do
           it "raises exception for invalid index" do
             expect { @vector[:foo] }.to raise_error(IndexError)
             expect { @vector[:a, :two, :foo] }.to raise_error(IndexError)
+            expect { @vector[:x, :one] }.to raise_error(IndexError)
           end
         end
       end


### PR DESCRIPTION
MultiIndex was working with invalid index : 
```ruby
mi = Daru::MultiIndex.from_tuples([ ['a',1,'x'] ,
                                    ['a',1,'y'] , 
                                    ['a',2,'x'] ,
                                    ['b',1,'y'] ,
                                    ['b',1,'z'] ,
                                    ['c',2,'z'] ])
 => Daru::MultiIndex:70139316645780 (levels: [["a", "b", "c"], [1, 2], ["x", "y", "z"]]
labels: [[0, 0, 0, 1, 1, 2], [0, 0, 1, 0, 0, 1], [0, 1, 0, 1, 2, 2]])
``` 
Accessing invalid index worked : 
```ruby
mi['p',1]
 => Daru::MultiIndex:70139316743800 (levels: [["a", "b"], [1], ["x", "y", "z"]]
labels: [[0, 0, 1, 1], [0, 0, 0, 0], [0, 1, 1, 2]])
```
This PR fixes this bug : 
```ruby
mi['p',1]
index.rb:256:in `block in retrieve_from_tuples': Specified index ["p", 1] do not exist (IndexError)
	from index.rb:254:in `each'
	from index.rb:254:in `each_with_index'
	from index.rb:254:in `retrieve_from_tuples'
	from index.rb:235:in `[]'
	from index.rb:373:in `<main>'
```