### PR TITLE
Adds explicit versions of hash conversion methods

### DIFF
--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -1865,9 +1865,15 @@ module Daru
       end
     end
 
-    # Converts DataFrame to a hash with keys as vector names and values as
+    # Converts DataFrame to a hash (implicit) with keys as vector names and values as
     # the corresponding vectors.
     def to_hash
+      to_h
+    end
+
+    # Converts DataFrame to a hash (explicit) with keys as vector names and values as
+    # the corresponding vectors.
+    def to_h
       hsh = {}
       @vectors.each_with_index do |vec_name, idx|
         hsh[vec_name] = @data[idx]

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -843,8 +843,13 @@ module Daru
       end
     end
 
-    # Convert to hash. Hash keys are indexes and values are the correspoding elements
+    # Convert to hash (implicit). Hash keys are indexes and values are the correspoding elements
     def to_hash
+      to_h
+    end
+
+    # Convert to hash (explicit). Hash keys are indexes and values are the correspoding elements
+    def to_h
       @index.inject({}) do |hsh, index|
         hsh[index] = self[index]
         hsh


### PR DESCRIPTION
This commit adds the explicit hash conversion method `to_h`
to both vectors and dataframes.  `to_hash` is an explicit conversion method.
I don't think it's really appropriate here (esp in DataFrame case), but
I'm not going to remove it because I don't want to break existing code.

For more on explicit/implicit conversions see http://trackmypop.com/blog/2013/06/16/language-awareness-ruby/
or the book "Confident Ruby" by Avdi Grimm.