### PR TITLE
bug in pivot_table solved

### DIFF
--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -1331,7 +1331,7 @@ module Daru
     #
     # @param [Daru::Index] idx New index object on which the rows of the dataframe
     #   are to be indexed.
-    # @example Reassgining index of a DataFrame
+    # @example Reassigning index of a DataFrame
     #   df = Daru::DataFrame.new({a: [1,2,3,4], b: [11,22,33,44]})
     #   df.index.to_a #=> [0,1,2,3]
     #
@@ -1578,6 +1578,10 @@ module Daru
       raise ArgumentError,
         "Specify grouping index" if !opts[:index] or opts[:index].empty?
 
+      arr = []
+      self.size.times {|i| arr[i] = i}
+      new_dataframe_index = Daru::Index.new(arr)
+      self.index = new_dataframe_index
       index   = opts[:index]
       vectors = opts[:vectors] || []
       aggregate_function = opts[:agg] || :mean
@@ -1630,7 +1634,6 @@ module Daru
 
         super_hash.each do |row_index, sub_h|
           sub_h.each do |vector_index, val|
-            # pivoted_dataframe[symbolize(vector_index)][symbolize(row_index)] = val
             pivoted_dataframe[vector_index][row_index] = val
           end
         end


### PR DESCRIPTION
This PR solves the issue [#49](https://github.com/v0dro/daru/issues/49). Describing briefly : 

Our `pivot_table` requires the index of dataframe to be in the form 0 -> numRows.  If you sort the dataframe then the index keys won't have values 0 -> numRows and things break down. Any dataframe with numerical index other than of the form 0 -> numRows will create error in `pivot_table`.

While `pivot_table` does not depend upon the dataframe index,  it would be best to first assign any dataframe index to 0 -> numRows and then carry out the regular routine for `pivot_table`.   