### PR TITLE
Fix doc recommending against using []

### DIFF
--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -357,8 +357,7 @@ module Daru
 
     # Access row or vector. Specify name of row/vector followed by axis(:row, :vector).
     # Defaults to *:vector*. Use of this method is not recommended for accessing
-    # rows or vectors. Use df.row[:a] for accessing row with index ':a' or
-    # df.vector[:vec] for accessing vector with index *:vec*.
+    # rows. Use df.row[:a] for accessing row with index ':a'.
     def [](*names)
       if names[-1] == :vector or names[-1] == :row
         axis = names[-1]


### PR DESCRIPTION
The comments on the #vector method say that it has been deprecated, but the comments
on #[] say to use #vector.  I think #[] is actually preferred.