### PR TITLE
Removes implicit to_hash conversions in favor of explicit to_h conversions

### DIFF
--- a/lib/daru/core/merge.rb
+++ b/lib/daru/core/merge.rb
@@ -29,7 +29,7 @@ module Daru
         end
 
         def hashify df
-          hsh = df.to_hash
+          hsh = df.to_h
           hsh.each { |k,v| hsh[k] = v.to_a }
           hsh
         end

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -1065,7 +1065,7 @@ module Daru
         name = row[tree_keys.last]
         if !block
           current[name] ||= []
-          current[name].push(row.to_hash.delete_if { |key,value| tree_keys.include? key})
+          current[name].push(row.to_h.delete_if { |key,value| tree_keys.include? key})
         else
           current[name] = block.call(row, current,name)
         end
@@ -1857,7 +1857,7 @@ module Daru
     def to_a
       arry = [[],[]]
       self.each_row do |row|
-        arry[0] << row.to_hash
+        arry[0] << row.to_h
       end
       arry[1] = @index.to_a
 
@@ -1872,12 +1872,6 @@ module Daru
       else
         self.to_a.to_json
       end
-    end
-
-    # Converts DataFrame to a hash (implicit) with keys as vector names and values as
-    # the corresponding vectors.
-    def to_hash
-      to_h
     end
 
     # Converts DataFrame to a hash (explicit) with keys as vector names and values as
@@ -2055,7 +2049,7 @@ module Daru
       row_num  = 1
 
       self.each_row_with_index do |row, index|
-        content += sprintf formatter, index.to_s, *row.to_hash.values.map { |e| (e || 'nil').to_s }
+        content += sprintf formatter, index.to_s, *row.to_h.values.map { |e| (e || 'nil').to_s }
         row_num += 1
         if row_num > threshold
           dots = []

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -847,11 +847,6 @@ module Daru
       end
     end
 
-    # Convert to hash (implicit). Hash keys are indexes and values are the correspoding elements
-    def to_hash
-      to_h
-    end
-
     # Convert to hash (explicit). Hash keys are indexes and values are the correspoding elements
     def to_h
       @index.inject({}) do |hsh, index|
@@ -865,9 +860,9 @@ module Daru
       @data.to_a
     end
 
-    # Convert the hash from to_hash to json
+    # Convert the hash from to_h to json
     def to_json *args
-      self.to_hash.to_json
+      self.to_h.to_json
     end
 
     # Convert to html for iruby

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -1206,9 +1206,9 @@ describe Daru::DataFrame do
     end
   end
 
-  context "#to_hash" do
+  context "#to_h" do
     it "converts to a hash" do
-      expect(@data_frame.to_hash).to eq(
+      expect(@data_frame.to_h).to eq(
         {
           a: Daru::Vector.new([1,2,3,4,5],
             index: [:one, :two, :three, :four, :five]),

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -446,13 +446,13 @@ describe Daru::Vector do
         end
       end
 
-      context "#to_hash" do
+      context "#to_h" do
         context Daru::Index do
           it "returns the vector as a hash" do
             dv = Daru::Vector.new [1,2,3,4,5], name: :a,
               index: [:one, :two, :three, :four, :five], dtype: dtype
 
-            expect(dv.to_hash).to eq({one: 1, two: 2, three: 3, four: 4, five: 5})
+            expect(dv.to_h).to eq({one: 1, two: 2, three: 3, four: 4, five: 5})
           end
         end
 
@@ -467,7 +467,7 @@ describe Daru::Vector do
           #     [:b,:two,:bar]
           #   ])
           #   vector = Daru::Vector.new([1,2,3,4], index: mi, dtype: dtype)
-          #   expect(vector.to_hash).to eq({
+          #   expect(vector.to_h).to eq({
           #     [:a,:two,:bar] => 1,
           #     [:a,:two,:baz] => 2,
           #     [:b,:one,:bar] => 3,


### PR DESCRIPTION
I don't think we should be defining implicit hash conversion functions.  Here's an example where we pass a dataframe to a method and Ruby *implicitly* converts it to a hash and populates the keyword arguments (`kargs`) instead of the array arguments (`args`).  The changes in this commit correctly put the dataframe in `args`.

Unfortunately, this will likely break some client code that uses `to_hash`, but I think it's the right direction.  I can't think of use cases where having an implicit conversion is particularly helpful.


```ruby
require 'daru'

df = Daru::DataFrame.new({ a: [1,2], b: [3,4] })

def mymeth(*args, **kargs)
  puts "args: #{args}"
  puts "kargs: #{kargs}"
end

mymeth(df)
```

    args: []
    kargs: {:a=>
    #<Daru::Vector:70093300385580 @name = a @metadata = {} @size = 2 >
          a
      0   1
      1   2
    , :b=>
    #<Daru::Vector:70093300385140 @name = b @metadata = {} @size = 2 >
          b
      0   3
      1   4
    }


