### PR TITLE
FIX - Improvement to dup performance

### DIFF
--- a/benchmarks/duplicating.rb
+++ b/benchmarks/duplicating.rb
@@ -1,0 +1,45 @@
+$:.unshift File.expand_path("../../lib", __FILE__)
+
+require 'benchmark'
+require 'daru'
+
+# Check scaling
+base_n = 10000
+0.upto(2) do |iscale|
+  n = base_n * 2**iscale
+
+  df_h = ('a'..'z').map { |v| v.to_sym }.reduce({}) do |h, v|
+    h[v] = Daru::Vector.new(1.upto(n).to_a)
+    h
+  end
+
+  df = Daru::DataFrame.new(df_h)
+
+  Benchmark.bm do |bm|
+    bm.report("dupe (n=#{n})") do
+      df.dup
+    end
+  end
+end
+
+#                   ===== Benchmarks =====
+# System: iMac Late 2013 3.5GHz Core i7
+#
+#       user     system      total        real
+#dupe (n=10000)  0.590000   0.020000   0.610000 (  0.613648)
+#       user     system      total        real
+#dupe (n=20000)  1.170000   0.040000   1.210000 (  1.236629)
+#       user     system      total        real
+#dupe (n=40000)  2.390000   0.070000   2.460000 (  2.511199)
+
+
+
+
+#                   ===== Prior Benchmarks (Daru 0.1.2 - 2707559369c03894a8394714820aabf116b99b20 - 2016-04-25) =====
+# Note that the n here is 100x smaller than above
+#       user     system      total        real
+#dupe (n=100)  0.220000   0.000000   0.220000 (  0.227924)
+#       user     system      total        real
+#dupe (n=200)  0.850000   0.000000   0.850000 (  0.856591)
+#       user     system      total        real
+#dupe (n=400)  3.370000   0.020000   3.390000 (  3.428211)

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -296,10 +296,10 @@ module Daru
         when Hash
           create_vectors_index_with vectors, source
           if all_daru_vectors_in_source? source
+            vectors_have_same_index = all_vectors_have_equal_indexes?(source)
             if !index.nil?
               @index = try_create_index index
-            elsif all_vectors_have_equal_indexes?(source)
-              vectors_have_same_index = true
+            elsif vectors_have_same_index
               @index = source.values[0].index.dup
             else
               all_indexes = []


### PR DESCRIPTION
Vectors were being completely recreated because there was no check
to see if the indexes were the same when the index was not nil.