### PR TITLE
fix #clone when passed no arguments

### DIFF
--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -454,7 +454,7 @@ module Daru
     # a view of the whole data frame otherwise.
     def clone *vectors_to_clone
       vectors_to_clone.flatten! unless vectors_to_clone.all? { |a| !a.is_a?(Array) }
-      return super if vectors_to_clone.empty?
+      vectors_to_clone = @vectors.to_a if vectors_to_clone.empty?
 
       h = vectors_to_clone.inject({}) do |hsh, vec|
         hsh[vec] = self[vec]

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -890,6 +890,16 @@ describe Daru::DataFrame do
       expect(cloned[:a].object_id).to eq(@data_frame[:a].object_id)
       expect(cloned[:b].object_id).to eq(@data_frame[:b].object_id)
     end
+
+    it "original dataframe remains unaffected when operations are applied
+      on cloned data frame" do
+      original = @data_frame.dup
+      cloned = @data_frame.clone
+      cloned.delete_vector :a
+
+      expect(@data_frame).to eq(original)
+    end
+
   end
 
   context "#clone_structure" do


### PR DESCRIPTION
Fix #111 

The problem was due to `#clone` working wrongly when passed no arguments. It was calling `#clone` method of super class which wasn't cloning the `@vectors` and other stuff leading to problems.