### PR TITLE
FIX - DataFrame#rename_vector when the new name is the same

### DIFF
--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -1378,7 +1378,7 @@ module Daru
     #   df.rename_vectors :a => :alpha, :c => :gamma
     #   df.vectors.to_a #=> [:alpha, :b, :gamma]
     def rename_vectors name_map
-      existing_targets = name_map.values & self.vectors.to_a
+      existing_targets = name_map.select { |k,v| k != v }.values & self.vectors.to_a
       delete_vectors *existing_targets
 
       new_names = self.vectors.to_a.map { |v| name_map[v] ? name_map[v] : v }

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -1499,6 +1499,14 @@ describe Daru::DataFrame do
       expect(@df.vectors.to_a).to eq([:b, :c])
       expect(@df[:b]).to eq saved_vector
     end
+
+    it "makes no changes if the old and new names are the same" do
+      saved_vector = @df[:a].dup
+
+      @df.rename_vectors :a => :a
+      expect(@df.vectors.to_a).to eq([:a, :b, :c])
+      expect(@df[:a]).to eq saved_vector
+    end
   end
 
   context "#reindex" do


### PR DESCRIPTION
When a vector was renamed to the same name, it was being deleted.

Resolves #117 