### PR TITLE
Include backports to add support for Ruby 2.0

### DIFF
--- a/daru.gemspec
+++ b/daru.gemspec
@@ -51,6 +51,7 @@ EOF
 
   spec.add_runtime_dependency 'reportbuilder', '~> 1.4'
   spec.add_runtime_dependency 'spreadsheet', '~> 1.1.1'
+  spec.add_runtime_dependency 'backports'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~>10.5'

--- a/lib/daru.rb
+++ b/lib/daru.rb
@@ -80,3 +80,5 @@ require 'daru/core/merge.rb'
 
 require 'daru/date_time/offsets.rb'
 require 'daru/date_time/index.rb'
+
+require 'backports'


### PR DESCRIPTION
Solves the problem of build failing in statsample-glm with Ruby 2.0. 

The reason why tests are still passing is that backports gets added to Daru because it's a development time dependency but when Daru is installed on a machine with Ruby 2.0, it fails.

This fix includes backports as run time dependency to Daru and thus fixes the problem.