### PR TITLE
Group by

### DIFF
--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -1254,7 +1254,7 @@ module Daru
     end
 
     def group_by *args
-      to_df.group_by *args
+      to_df.group_by(*args)
     end
 
     # Converts a non category type vector to category type vector.

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -1249,6 +1249,14 @@ module Daru
 
     alias :dv :daru_vector
 
+    def to_df
+      DataFrame.new([self], order: [name])
+    end
+
+    def group_by *args
+      to_df.group_by *args
+    end
+
     # Converts a non category type vector to category type vector.
     # @param [Hash] opts options to convert to category
     # @option opts [true, false] :ordered Specify if vector is ordered or not.

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -1249,10 +1249,6 @@ module Daru
 
     alias :dv :daru_vector
 
-    def to_df
-      DataFrame.new([self], order: [name])
-    end
-
     def group_by *args
       to_df.group_by(*args)
     end

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -1936,16 +1936,6 @@ describe Daru::Vector do
     end
   end
 
-  context "#to_df" do
-    it "converts vector to DataFrame containing that vector" do
-      dv = Daru::Vector.new 1..10, name: :a
-      df = Daru::DataFrame.new({
-        a: 1..10
-      })
-      expect(dv.to_df).to eq(df)
-    end
-  end
-
   context "#group_by" do
     it "redirects to DataFrame::group_by" do
       dv = Daru::Vector.new [1, 1, 2, 2, 3], name: :a

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -1936,4 +1936,21 @@ describe Daru::Vector do
     end
   end
 
+  context "#to_df" do
+    it "converts vector to DataFrame containing that vector" do
+      dv = Daru::Vector.new 1..10, name: :a
+      df = Daru::DataFrame.new({
+        a: 1..10
+      })
+      expect(dv.to_df).to eq(df)
+    end
+  end
+
+  context "#group_by" do
+    it "redirects to DataFrame::group_by" do
+      dv = Daru::Vector.new [1, 1, 2, 2, 3], name: :a
+      expect(dv.group_by([:a]).groups).to eq(dv.to_df.group_by([:a]).groups)
+    end
+  end
+
 end if mri?


### PR DESCRIPTION
Fixes #120 by creating a custom Daru::Vector::group_by which redirects to Daru::DataFrame where DataFrame is the one containing only that vector.

Also create a function `to_df` to convert a vector to a DataFrame containing only that vector.