### PR TITLE
Better #inspect for core classes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -66,6 +66,9 @@ Style/SpaceAroundOperators:
 Style/EmptyCaseCondition:
   Enabled: false
 
+Style/MultilineBlockChain:
+  Enabled: false
+
 # Neither of prefered styles are good enough :(
 Style/BlockDelimiters:
   Enabled: false

--- a/lib/daru.rb
+++ b/lib/daru.rb
@@ -77,6 +77,7 @@ require 'daru/index.rb'
 require 'daru/vector.rb'
 require 'daru/dataframe.rb'
 require 'daru/monkeys.rb'
+require 'daru/formatters/table'
 
 require 'daru/core/group_by.rb'
 require 'daru/core/query.rb'

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -1606,8 +1606,9 @@ module Daru
     # Pretty print in a nice table format for the command line (irb/pry/iruby)
     def inspect spacing=10, threshold=15
       row_headers = index.is_a?(MultiIndex) ? index.sparse_tuples : index.to_a
+      name_part = @name ? ": #{@name} " : ''
 
-      "#<#{self.class}: #{@name || 'nil'} (#{ncols}x#{nrows})>\n" +
+      "#<#{self.class}#{name_part}(#{ncols}x#{nrows})>\n" +
         Formatters::Table.format(
           each_row.lazy,
           row_headers: row_headers,

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -1605,26 +1605,16 @@ module Daru
 
     # Pretty print in a nice table format for the command line (irb/pry/iruby)
     def inspect spacing=10, threshold=15
-      name      = @name || 'nil'
-      formatter = make_formatter spacing
+      row_headers = index.is_a?(MultiIndex) ? index.sparse_tuples : index.to_a
 
-      rows = [
-        # column titles
-        ['', *@vectors],
-
-        # column values
-        *each_row_with_index.first(threshold).map { |row, index|
-          [index, *row.to_h.values.map { |e| e || 'nil' }]
-        },
-
-        # "more" dots
-        size > threshold ? ['...'] * (@vectors.size + 1) : nil
-      ].compact
-
-      [
-        "#<#{self.class}:#{object_id} @name = #{name} @size = #{@size}>",
-        *rows.map { |r| formatter % r }
-      ].join
+      "#<#{self.class}: #{@name || 'nil'} (#{ncols}x#{nrows})>\n" +
+        Formatters::Table.format(
+          each_row.lazy,
+          row_headers: row_headers,
+          headers: vectors,
+          threshold: threshold,
+          spacing: spacing
+        )
     end
 
     # Query a DataFrame by passing a Daru::Core::Query::BoolArray object.
@@ -1685,19 +1675,6 @@ module Daru
       else
         default
       end
-    end
-
-    def make_formatter spacing
-      # FIXME: for very large dataframes, this @data.map may be pretty costly?
-      longest = [
-        (@vectors.map(&:to_s).map(&:size).max || 0),
-        (@index  .map(&:to_s).map(&:size).max || 0),
-        (@data   .map { |v| v.map(&:to_s).map(&:size).max }.max || 0),
-        3, # size of 'nil' and '...'
-      ].max
-
-      longest = [longest, spacing].min
-      "\n" + (["%#{longest}.#{longest}s"] * (@vectors.size + 1)).join(' ')
     end
 
     def access_vector *names

--- a/lib/daru/date_time/index.rb
+++ b/lib/daru/date_time/index.rb
@@ -401,9 +401,9 @@ module Daru
     end
 
     def inspect
-      "#<DateTimeIndex:#{object_id} offset=#{@frequency || 'nil'}" \
-         " periods=#{@periods}" \
-         " data=[#{@data.first[0]}...#{@data.last[0]}]>"
+      meta = [@periods, @frequency ? "frequency=#{@frequency}" : nil].compact.join(', ')
+      "#<#{self.class}(#{meta}) " \
+         "#{@data.first[0]}...#{@data.last[0]}>"
     end
 
     # Shift all dates in the index by a positive number in the future. The dates

--- a/lib/daru/formatters/table.rb
+++ b/lib/daru/formatters/table.rb
@@ -1,0 +1,54 @@
+module Daru
+  module Formatters
+    class Table
+      def self.format data, options={}
+        new(data, options[:headers], options[:row_headers])
+          .format(options[:threshold], options[:spacing])
+      end
+
+      def initialize(data, headers, row_headers)
+        @data = data || []
+        @headers = (headers || []).to_a
+        @row_headers = (row_headers || []).to_a
+      end
+
+      DEFAULT_SPACING = 10
+      DEFAULT_THRESHOLD = 15
+
+      def format threshold=nil, spacing=nil
+        rows = build_rows(threshold || DEFAULT_THRESHOLD)
+
+        formatter = construct_formatter rows, spacing || DEFAULT_SPACING
+
+        rows.map { |r| formatter % r }.join("\n")
+      end
+
+      private
+
+      def build_rows threshold # rubocop:disable Metrics/AbcSize
+        @row_headers.first(threshold).zip(@data).map do |(r, datarow)|
+          [*[r].flatten.map(&:to_s), *(datarow || []).map(&method(:pretty_to_s))]
+        end.tap do |rows|
+          unless @headers.empty?
+            spaces_to_add = rows.empty? ? 0 : rows.first.size - @headers.size
+            rows.unshift [''] * spaces_to_add + @headers.map(&:to_s)
+          end
+
+          rows << ['...'] * rows.first.count if @row_headers.count > threshold
+        end
+      end
+
+      def construct_formatter rows, spacing
+        width = rows.flatten.map(&:size).max
+        width = [3, width].max # not less than 'nil'
+        width = [width, spacing].min # not more than max width
+
+        " %#{width}.#{width}s" * rows.first.size
+      end
+
+      def pretty_to_s(val)
+        val.nil? ? 'nil' : val.to_s
+      end
+    end
+  end
+end

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -851,7 +851,7 @@ module Daru
     def inspect spacing=20, threshold=15
       row_headers = index.is_a?(MultiIndex) ? index.sparse_tuples : index.to_a
 
-      "#<#{self.class}(#{size})>\n" +
+      "#<#{self.class}(#{size})#{metadata && !metadata.empty? ? metadata.inspect : ''}>\n" +
         Formatters::Table.format(
           @data.lazy.map { |v| [v] },
           headers: [@name || 'nil'],

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -849,16 +849,16 @@ module Daru
 
     # Over rides original inspect for pretty printing in irb
     def inspect spacing=20, threshold=15
-      name      = @name || 'nil'
-      metadata  = @metadata || 'nil'
-      formatter = make_format_string spacing
+      row_headers = index.is_a?(MultiIndex) ? index.sparse_tuples : index.to_a
 
-      [
-        "#<#{self.class}:#{object_id} @name = #{name} @metadata = #{metadata} @size = #{size} >",
-        formatter % ['', name],
-        @index.first(threshold).map { |idx| formatter % [idx, self[*idx] || 'nil'] },
-        size > threshold ? formatter % ['...', '...'] : ''
-      ].flatten.join
+      "#<#{self.class}(#{size})>\n" +
+        Formatters::Table.format(
+          @data.lazy.map { |v| [v] },
+          headers: [@name || 'nil'],
+          row_headers: row_headers,
+          threshold: threshold,
+          spacing: spacing
+        )
     end
 
     # Sets new index for vector. Preserves index->value correspondence.
@@ -1094,19 +1094,6 @@ module Daru
     end
 
     private
-
-    def make_format_string spacing
-      longest =
-        [
-          @name.to_s.size,
-          (@index.to_a.map(&:to_s).map(&:size).max || 0),
-          (@data.map(&:to_s).map(&:size).max || 0),
-          3 # 'nil'.size
-        ].max
-
-      longest = [longest, spacing].min
-      "\n%#{longest}.#{longest}s %#{longest}.#{longest}s"
-    end
 
     def parse_source source, opts
       if source.is_a?(Hash)

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -854,7 +854,7 @@ module Daru
       "#<#{self.class}(#{size})#{metadata && !metadata.empty? ? metadata.inspect : ''}>\n" +
         Formatters::Table.format(
           @data.lazy.map { |v| [v] },
-          headers: [@name || 'nil'],
+          headers: @name && [@name],
           row_headers: row_headers,
           threshold: threshold,
           spacing: spacing

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -2656,69 +2656,101 @@ describe Daru::DataFrame do
     context 'empty' do
       let(:df) { Daru::DataFrame.new({}, order: %w[a b c])}
       it { is_expected.to eq %Q{
-        |#<Daru::DataFrame:#{df.object_id} @name = nil @size = 0>
-        |      a   b   c
+        |#<Daru::DataFrame: #{df.name} (3x0)>
+        |   a   b   c
       }.unindent}
     end
 
     context 'simple' do
       let(:df) { Daru::DataFrame.new({a: [1,2,3], b: [3,4,5], c: [6,7,8]}, name: 'test')}
       it { should == %Q{
-        |#<Daru::DataFrame:#{df.object_id} @name = test @size = 3>
-        |      a   b   c
-        |  0   1   3   6
-        |  1   2   4   7
-        |  2   3   5   8
+        |#<Daru::DataFrame: test (3x3)>
+        |       a   b   c
+        |   0   1   3   6
+        |   1   2   4   7
+        |   2   3   5   8
        }.unindent}
     end
 
     context 'with nils' do
       let(:df) { Daru::DataFrame.new({a: [1,nil,3], b: [3,4,5], c: [6,7,nil]}, name: 'test')}
       it { is_expected.to eq %Q{
-        |#<Daru::DataFrame:#{df.object_id} @name = test @size = 3>
-        |      a   b   c
-        |  0   1   3   6
-        |  1 nil   4   7
-        |  2   3   5 nil
+        |#<Daru::DataFrame: test (3x3)>
+        |       a   b   c
+        |   0   1   3   6
+        |   1 nil   4   7
+        |   2   3   5 nil
        }.unindent}
     end
 
     context 'very long' do
       let(:df) { Daru::DataFrame.new({a: [1,1,1]*20, b: [1,1,1]*20, c: [1,1,1]*20}, name: 'test')}
-      it { should == %Q{
-        |#<Daru::DataFrame:#{df.object_id} @name = test @size = 60>
-        |      a   b   c
-        |  0   1   1   1
-        |  1   1   1   1
-        |  2   1   1   1
-        |  3   1   1   1
-        |  4   1   1   1
-        |  5   1   1   1
-        |  6   1   1   1
-        |  7   1   1   1
-        |  8   1   1   1
-        |  9   1   1   1
-        | 10   1   1   1
-        | 11   1   1   1
-        | 12   1   1   1
-        | 13   1   1   1
-        | 14   1   1   1
-        |... ... ... ...
+      it { is_expected.to eq %Q{
+        |#<Daru::DataFrame: test (3x60)>
+        |       a   b   c
+        |   0   1   1   1
+        |   1   1   1   1
+        |   2   1   1   1
+        |   3   1   1   1
+        |   4   1   1   1
+        |   5   1   1   1
+        |   6   1   1   1
+        |   7   1   1   1
+        |   8   1   1   1
+        |   9   1   1   1
+        |  10   1   1   1
+        |  11   1   1   1
+        |  12   1   1   1
+        |  13   1   1   1
+        |  14   1   1   1
+        | ... ... ... ...
        }.unindent}
     end
 
     context 'long data lines' do
       let(:df) { Daru::DataFrame.new({a: [1,2,3], b: [4,5,6], c: ['this is ridiculously long',nil,nil]}, name: 'test')}
-      it { should == %Q{
-        |#<Daru::DataFrame:#{df.object_id} @name = test @size = 3>
-        |                    a          b          c
-        |         0          1          4 this is ri
-        |         1          2          5        nil
-        |         2          3          6        nil
+      it { is_expected.to eq %Q{
+        |#<Daru::DataFrame: test (3x3)>
+        |                     a          b          c
+        |          0          1          4 this is ri
+        |          1          2          5        nil
+        |          2          3          6        nil
        }.unindent}
     end
 
-    context 'multi-index' do
+    context 'index is a MultiIndex' do
+      let(:df) {
+        Daru::DataFrame.new(
+          {
+            a:   [1,2,3,4,5,6,7],
+            b: %w[a b c d e f g]
+          }, index: Daru::MultiIndex.from_tuples([
+                %w[foo one],
+                %w[foo two],
+                %w[foo three],
+                %w[bar one],
+                %w[bar two],
+                %w[bar three],
+                %w[baz one],
+             ]),
+             name: 'test'
+        )
+      }
+
+      it { is_expected.to eq %Q{
+        |#<Daru::DataFrame: test (2x7)>
+        |                 a     b
+        |   foo   one     1     a
+        |         two     2     b
+        |       three     3     c
+        |   bar   one     4     d
+        |         two     5     e
+        |       three     6     f
+        |   baz   one     7     g
+      }.unindent}
+    end
+
+    context 'vectors is a MultiIndex' do
     end
 
     context 'spacing and threshold settings' do

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -2656,7 +2656,7 @@ describe Daru::DataFrame do
     context 'empty' do
       let(:df) { Daru::DataFrame.new({}, order: %w[a b c])}
       it { is_expected.to eq %Q{
-        |#<Daru::DataFrame: #{df.name} (3x0)>
+        |#<Daru::DataFrame(3x0)>
         |   a   b   c
       }.unindent}
     end
@@ -2665,6 +2665,17 @@ describe Daru::DataFrame do
       let(:df) { Daru::DataFrame.new({a: [1,2,3], b: [3,4,5], c: [6,7,8]}, name: 'test')}
       it { should == %Q{
         |#<Daru::DataFrame: test (3x3)>
+        |       a   b   c
+        |   0   1   3   6
+        |   1   2   4   7
+        |   2   3   5   8
+       }.unindent}
+    end
+
+    context 'no name' do
+      let(:df) { Daru::DataFrame.new({a: [1,2,3], b: [3,4,5], c: [6,7,8]})}
+      it { should == %Q{
+        |#<Daru::DataFrame(3x3)>
         |       a   b   c
         |   0   1   3   6
         |   1   2   4   7

--- a/spec/date_time/index_spec.rb
+++ b/spec/date_time/index_spec.rb
@@ -179,14 +179,29 @@ describe DateTimeIndex do
   end
 
   context '#inspect' do
-    it 'works, you know' do
-      index = DateTimeIndex.new([
-        DateTime.new(2014,7,1),DateTime.new(2014,7,2),DateTime.new(2014,7,3),
-        DateTime.new(2014,7,4)], freq: :infer)
-      expect(index.inspect).to eq("#<DateTimeIndex:#{index.object_id} offset=D periods=4 data=[2014-07-01T00:00:00+00:00...2014-07-04T00:00:00+00:00]>")
+    subject { index.inspect }
+
+    context 'with known frequency' do
+      let(:index){
+        DateTimeIndex.new([
+          DateTime.new(2014,7,1),DateTime.new(2014,7,2),DateTime.new(2014,7,3),
+          DateTime.new(2014,7,4)], freq: :infer)
+      }
+      it { is_expected.to eq \
+        "#<Daru::DateTimeIndex(4, frequency=D) 2014-07-01T00:00:00+00:00...2014-07-04T00:00:00+00:00>"
+      }
     end
 
-    # FIXME: Personally I'd prefer more compact inspects, like #<DateTimeIndex[D](2014-07-01 - 2014-07-04)>, or something like it - zverok
+    context 'with unknown frequency' do
+      let(:index){
+        DateTimeIndex.new([
+          DateTime.new(2014,7,1),DateTime.new(2014,7,2),DateTime.new(2014,7,3),
+          DateTime.new(2014,7,4)])
+      }
+      it { is_expected.to eq \
+        "#<Daru::DateTimeIndex(4) 2014-07-01T00:00:00+00:00...2014-07-04T00:00:00+00:00>"
+      }
+    end
   end
 
   context "#frequency" do

--- a/spec/formatters/table_formatter_spec.rb
+++ b/spec/formatters/table_formatter_spec.rb
@@ -1,0 +1,99 @@
+describe Daru::Formatters::Table do
+  let(:options) { {} }
+  subject {
+    Daru::Formatters::Table
+      .format(data, options.merge(headers: headers, row_headers: row_headers))
+  }
+
+  let(:data) { [[1,2,3], [4,5,6], [7,8,9]] }
+  let(:headers) { [:col1, :col2, :col3] }
+  let(:row_headers) { [:row1, :row2, :row3] }
+
+  context 'simple table' do
+    it { is_expected.to eq %Q{
+      |      col1 col2 col3
+      | row1    1    2    3
+      | row2    4    5    6
+      | row3    7    8    9
+    }.unindent}
+  end
+
+  context 'with nils' do
+    let(:data) { [[1,nil,3], [4,5,nil], [7,8,9]] }
+    let(:headers) { [:col1, :col2, nil] }
+    let(:row_headers) { [:row1, nil, :row3] }
+
+    it { is_expected.to eq %Q{
+      |      col1 col2     |
+      | row1    1  nil    3|
+      |         4    5  nil|
+      | row3    7    8    9|
+    }.unindent}
+  end
+
+  context 'with multivalue row headers' do
+    let(:row_headers) { [[:row,1], [:row,2], [:row,3]] }
+    it { is_expected.to eq %Q{
+      |           col1 col2 col3
+      |  row    1    1    2    3
+      |  row    2    4    5    6
+      |  row    3    7    8    9
+    }.unindent}
+  end
+
+  context 'with multivalue column headers' do
+    let(:headers) { [[:col,1], [:col,2], [:col,3]] }
+  end
+
+  context 'rows only' do
+    let(:data) { [] }
+    let(:headers) { nil }
+    it { is_expected.to eq %Q{
+      | row1
+      | row2
+      | row3
+    }.unindent}
+  end
+
+  context 'columns only' do
+    let(:data) { [] }
+    let(:row_headers) { nil }
+    it { is_expected.to eq %Q{
+      | col1 col2 col3
+    }.unindent}
+  end
+
+  context 'wide values' do
+    let(:options) { {spacing: 2} }
+
+    it { is_expected.to eq %Q{
+      |    co co co
+      | ro  1  2  3
+      | ro  4  5  6
+      | ro  7  8  9
+    }.unindent}
+  end
+
+  context '<more> threshold' do
+    let(:options) { {threshold: threshold} }
+    context 'lower than data size' do
+      let(:threshold) { 2 }
+      it { is_expected.to eq %Q{
+        |      col1 col2 col3
+        | row1    1    2    3
+        | row2    4    5    6
+        |  ...  ...  ...  ...
+      }.unindent}
+    end
+
+    context 'greater than data size' do
+      let(:threshold) { 5 }
+      it { is_expected.to eq %Q{
+        |      col1 col2 col3
+        | row1    1    2    3
+        | row2    4    5    6
+        | row3    7    8    9
+      }.unindent}
+    end
+  end
+end

--- a/spec/index_spec.rb
+++ b/spec/index_spec.rb
@@ -76,6 +76,18 @@ describe Daru::Index do
     end
   end
 
+  context '#inspect' do
+    context 'small index' do
+      subject { Daru::Index.new ['one', 'two', 'three']  }
+      its(:inspect) { is_expected.to eq "#<Daru::Index(3): {one, two, three}>" }
+    end
+
+    context 'large index' do
+      subject { Daru::Index.new ('a'..'z').to_a  }
+      its(:inspect) { is_expected.to eq "#<Daru::Index(26): {a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t ... z}>" }
+    end
+  end
+
   context "#&" do
     before :each do
       @left = Daru::Index.new [:miles, :geddy, :eric]
@@ -328,8 +340,74 @@ describe Daru::MultiIndex do
   end
 
   context "inspect" do
-    it "provides reasonable inspect" do
-      expect(@multi_mi.inspect).to eq "#<Daru::MultiIndex:#{@multi_mi.object_id} (levels: [[:a, :b, :c], [:one, :two], [:bar, :baz, :foo]]\nlabels: [[0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2], [0, 0, 1, 1, 0, 1, 1, 0, 0, 0, 1, 1], [0, 1, 0, 1, 0, 0, 1, 2, 0, 1, 2, 0]])>"
+    context 'small index' do
+      subject {
+        Daru::MultiIndex.from_tuples [
+          [:a,:one,:bar],
+          [:a,:one,:baz],
+          [:a,:two,:bar],
+          [:a,:two,:baz],
+          [:b,:one,:bar],
+          [:b,:two,:bar],
+          [:b,:two,:baz],
+          [:b,:one,:foo],
+          [:c,:one,:bar],
+          [:c,:one,:baz],
+          [:c,:two,:foo],
+          [:c,:two,:bar]
+        ]
+      }
+
+      its(:inspect) { is_expected.to eq %Q{
+        |#<Daru::MultiIndex(3x12)>
+        |   a one bar
+        |         baz
+        |     two bar
+        |         baz
+        |   b one bar
+        |     two bar
+        |         baz
+        |     one foo
+        |   c one bar
+        |         baz
+        |     two foo
+        |         bar
+        }.unindent
+      }
+    end
+
+    context 'large index' do
+      subject {
+        Daru::MultiIndex.from_tuples(
+          (1..100).map { |i| %w[a b c].map { |c| [i, c] } }.flatten(1)
+        )
+      }
+
+      its(:inspect) { is_expected.to eq %Q{
+        |#<Daru::MultiIndex(2x300)>
+        |   1   a
+        |       b
+        |       c
+        |   2   a
+        |       b
+        |       c
+        |   3   a
+        |       b
+        |       c
+        |   4   a
+        |       b
+        |       c
+        |   5   a
+        |       b
+        |       c
+        |   6   a
+        |       b
+        |       c
+        |   7   a
+        |       b
+        | ... ...
+        }.unindent
+      }
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,8 +58,9 @@ class String
   # "test
   # me"
   def unindent
-    gsub(/\n\s+?\|/, "\n").  # for all lines looking like "<spaces>|" -- remove this.
-    gsub(/^\n|\n\s+$/, '')   # remove empty strings before and after
+    gsub(/\n\s+?\|/, "\n")    # for all lines looking like "<spaces>|" -- remove this.
+    .gsub(/\|\n/, "\n")       # allow to write trailing space not removed by editor
+    .gsub(/^\n|\n\s+$/, '')   # remove empty strings before and after
   end
 end
 

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -1324,6 +1324,16 @@ describe Daru::Vector do
       }.unindent }
     end
 
+    context 'no name' do
+      subject(:vector) { Daru::Vector.new [1,2,3], index: [:a, :b, :c] }
+      its(:inspect) { is_expected.to eq %Q{
+        |#<Daru::Vector(3)>
+        |   a   1
+        |   b   2
+        |   c   3
+      }.unindent }
+    end
+
     context 'with nils' do
       subject(:vector) { Daru::Vector.new [1,nil,3], index: [:a, :b, :c], name: 'test' }
       its(:inspect) { is_expected.to eq %Q{

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -1335,6 +1335,17 @@ describe Daru::Vector do
       }.unindent }
     end
 
+    context 'with metadata' do
+      subject(:vector) { Daru::Vector.new [1,2,3], index: [:a, :b, :c], name: 'test', metadata: {hey: 'JUDE!'} }
+      its(:inspect) { is_expected.to eq %Q{
+        |#<Daru::Vector(3){:hey=>"JUDE!"}>
+        |      test
+        |    a    1
+        |    b    2
+        |    c    3
+      }.unindent }
+    end
+
     context 'very large amount of data' do
       subject(:vector) { Daru::Vector.new [1,2,3] * 100, name: 'test' }
       its(:inspect) { is_expected.to eq %Q{

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -1316,46 +1316,46 @@ describe Daru::Vector do
     context 'simple' do
       subject(:vector) { Daru::Vector.new [1,2,3], index: [:a, :b, :c], name: 'test' }
       its(:inspect) { is_expected.to eq %Q{
-        |#<Daru::Vector:#{vector.object_id} @name = test @metadata = {} @size = 3 >
-        |     test
-        |   a    1
-        |   b    2
-        |   c    3
+        |#<Daru::Vector(3)>
+        |      test
+        |    a    1
+        |    b    2
+        |    c    3
       }.unindent }
     end
 
     context 'with nils' do
       subject(:vector) { Daru::Vector.new [1,nil,3], index: [:a, :b, :c], name: 'test' }
       its(:inspect) { is_expected.to eq %Q{
-        |#<Daru::Vector:#{vector.object_id} @name = test @metadata = {} @size = 3 >
-        |     test
-        |   a    1
-        |   b  nil
-        |   c    3
+        |#<Daru::Vector(3)>
+        |      test
+        |    a    1
+        |    b  nil
+        |    c    3
       }.unindent }
     end
 
     context 'very large amount of data' do
       subject(:vector) { Daru::Vector.new [1,2,3] * 100, name: 'test' }
       its(:inspect) { is_expected.to eq %Q{
-        |#<Daru::Vector:#{vector.object_id} @name = test @metadata = {} @size = 300 >
-        |     test
-        |   0    1
-        |   1    2
-        |   2    3
-        |   3    1
-        |   4    2
-        |   5    3
-        |   6    1
-        |   7    2
-        |   8    3
-        |   9    1
-        |  10    2
-        |  11    3
-        |  12    1
-        |  13    2
-        |  14    3
-        | ...  ...
+        |#<Daru::Vector(300)>
+        |      test
+        |    0    1
+        |    1    2
+        |    2    3
+        |    3    1
+        |    4    2
+        |    5    3
+        |    6    1
+        |    7    2
+        |    8    3
+        |    9    1
+        |   10    2
+        |   11    3
+        |   12    1
+        |   13    2
+        |   14    3
+        |  ...  ...
       }.unindent }
     end
 
@@ -1364,12 +1364,42 @@ describe Daru::Vector do
         index: [:a, :b, :c], name: 'and this is not much better faithfully'
       }
       its(:inspect) { is_expected.to eq %Q{
-        |#<Daru::Vector:#{vector.object_id} @name = and this is not much better faithfully @metadata = {} @size = 3 >
-        |                     and this is not much
-        |                   a                    1
-        |                   b                    2
-        |                   c this is ridiculously
+        |#<Daru::Vector(3)>
+        |                      and this is not much
+        |                    a                    1
+        |                    b                    2
+        |                    c this is ridiculously
       }.unindent }
+    end
+
+    context 'with multiindex' do
+      subject(:vector) {
+        Daru::Vector.new(
+          [1,2,3,4,5,6,7],
+          name: 'test',
+          index: Daru::MultiIndex.from_tuples([
+              %w[foo one],
+              %w[foo two],
+              %w[foo three],
+              %w[bar one],
+              %w[bar two],
+              %w[bar three],
+              %w[baz one],
+           ]),
+        )
+      }
+
+      its(:inspect) { is_expected.to eq %Q{
+        |#<Daru::Vector(7)>
+        |              test
+        |   foo   one     1
+        |         two     2
+        |       three     3
+        |   bar   one     4
+        |         two     5
+        |       three     6
+        |   baz   one     7
+      }.unindent}
     end
 
     context 'threshold and spacing settings' do


### PR DESCRIPTION
Main changes:
* all main objects' `inspect`s changed to represent data, not internal state, and be more compact in this;
* factor out logic of "table with adaptive column width and limited rows count" into `Formatters::Table`;
* much better (or I hope so) inspect for multi-indexes, multi-index vectors and dataframes.

Examples:

**Daru::Index**:
```ruby
Daru::Index.new('a'..'z')

# before
# => #<Daru::Index:0x93ac470 @relation_hash={"a"=>0, "b"=>1, "c"=>2, "d"=>3, "e"=>4, "f"=>5, "g"=>6, "h"=>7, "i"=>8, "j"=>9, "k"=>10, "l"=>11, "m"=>12, "n"=>13, "o"=>14, "p"=>15, "q"=>16, "r"=>17, "s"=>18, "t"=>19, "u"=>20, "v"=>21, "w"=>22, "x"=>23, "y"=>24, "z"=>25}, @keys=["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"], @size=26>

# after
# => #<Daru::Index(26): {a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t ... z}>
```

**Daru::MultiIndex**:
```ruby
mi = Daru::MultiIndex.from_tuples [
  [:a,:one,:bar],
  [:a,:one,:baz],
  [:a,:two,:bar],
  [:a,:two,:baz],
  [:b,:one,:bar],
  [:b,:two,:bar],
  [:b,:two,:baz],
  [:b,:one,:foo],
  [:c,:one,:bar],
  [:c,:one,:baz],
  [:c,:two,:foo],
  [:c,:two,:bar]
]

# before
#  => #<Daru::MultiIndex:77179890 (levels: [[:a, :b, :c], [:one, :two], [:bar, :baz, :foo]]
# labels: [[0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2], [0, 0, 1, 1, 0, 1, 1, 0, 0, 0, 1, 1], [0, 1, 0, 1, 0, 0, 1, 2, 0, 1, 2, 0]])> 

# after
# => #<Daru::MultiIndex(3x12)>
#   a one bar
#         baz
#     two bar
#         baz
#   b one bar
#     two bar
#         baz
#     one foo
#   c one bar
#         baz
#     two foo
#         bar 
```

**Daru::Vector**:
```ruby
Daru::Vector.new [1,2,3], name: 'foo'
# => #<Daru::Vector:77150670 @name = foo @metadata = {} @size = 3 >
#    foo
#  0   1
#  1   2
#  2   3 

# after
# => #<Daru::Vector(3)>
#     foo
#   0   1
#   1   2
#   2   3

# with multi-index
Daru::Vector.new (1..12), index: mi, name: 'foo'

# before
# => #<Daru::Vector:77029920 @name = foo @metadata = {} @size = 12 >
#                               foo
# [:a, :one, :bar]                1
# [:a, :one, :baz]                2
# [:a, :two, :bar]                3
# [:a, :two, :baz]                4
# [:b, :one, :bar]                5
# [:b, :two, :bar]                6
# [:b, :two, :baz]                7
# [:b, :one, :foo]                8
# [:c, :one, :bar]                9
# [:c, :one, :baz]               10
# [:c, :two, :foo]               11
# [:c, :two, :bar]               12 

# after
# => #<Daru::Vector(12)>
#             foo
#   a one bar   1
#         baz   2
#     two bar   3
#         baz   4
#   b one bar   5
#     two bar   6
#         baz   7
#     one foo   8
#   c one bar   9
#         baz  10
#     two foo  11
#         bar  12 
```

**Daru::DataFrame**:
```ruby
Daru::DataFrame.new({a: [1,2,3], b: [3,4,5], c: [6,7,8]}, name: 'test')

# before
# => #<Daru::DataFrame:76902890 @name = test @size = 3>
#      a   b   c
#  0   1   3   6
#  1   2   4   7
#  2   3   5   8 


# after
# => #<Daru::DataFrame: test (3x3)>
#       a   b   c
#   0   1   3   6
#   1   2   4   7
#   2   3   5   8 

# with multi-index

Daru::DataFrame.new({a: (1..12), b: ('a'..'l'), c: (1001..1012)}, index: mi, name: 'test')

# before
#  => #<Daru::DataFrame:76819850 @name = test @size = 12>
#                     a          b          c
# [:a, :one,          1          a       1001
# [:a, :one,          2          b       1002
# [:a, :two,          3          c       1003
# [:a, :two,          4          d       1004
# [:b, :one,          5          e       1005
# [:b, :two,          6          f       1006
# [:b, :two,          7          g       1007
# [:b, :one,          8          h       1008
# [:c, :one,          9          i       1009
# [:c, :one,         10          j       1010
# [:c, :two,         11          k       1011
# [:c, :two,         12          l       1012 

# after
# => #<Daru::DataFrame: test (3x12)>
#                   a    b    c
#    a  one  bar    1    a 1001
#            baz    2    b 1002
#       two  bar    3    c 1003
#            baz    4    d 1004
#    b  one  bar    5    e 1005
#       two  bar    6    f 1006
#            baz    7    g 1007
#       one  foo    8    h 1008
#    c  one  bar    9    i 1009
#            baz   10    j 1010
#       two  foo   11    k 1011
#            bar   12    l 1012 
```