### PR TITLE
Better `#to_html` for core classes

### DIFF
--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -1496,7 +1496,11 @@ module Daru
 
     # Convert to html for IRuby.
     def to_html threshold=30
-      path = File.expand_path('../iruby/templates/dataframe.html.erb', __FILE__)
+      path = if index.is_a?(MultiIndex)
+               File.expand_path('../iruby/templates/dataframe_mi.html.erb', __FILE__)
+             else
+               File.expand_path('../iruby/templates/dataframe.html.erb', __FILE__)
+             end
       ERB.new(File.read(path).strip).result(binding)
     end
 

--- a/lib/daru/index.rb
+++ b/lib/daru/index.rb
@@ -364,6 +364,11 @@ module Daru
         Formatters::Table.format([], row_headers: sparse_tuples, threshold: threshold)
     end
 
+    def to_html
+      path = File.expand_path('../iruby/templates/multi_index.html.erb', __FILE__)
+      ERB.new(File.read(path).strip).result(binding)
+    end
+
     # Provide a MultiIndex for sub vector produced
     #
     # @param input_indexes [Array] the input by user to index the vector
@@ -385,6 +390,33 @@ module Daru
         left = cur.zip(prev).drop_while { |c, p| c == p }
         [nil] * (cur.size - left.size) + left.map(&:first)
       }
+    end
+
+    def tuples_with_rowspans
+      sparse_tuples
+        .transpose
+        .map { |r| nils_counted(r) }
+        .transpose.map(&:compact)
+    end
+
+    private
+
+    # It is complicated, but the only algo I could think.
+    # It does [:a, nil, nil, :b, nil, :c] # =>
+    #         [[:a,3], nil, nil, [:b,2], nil, :c]
+    # Needed by tuples_with_rowspans, which we need for pretty HTML
+    def nils_counted array
+      grouped = [[array.first]]
+      array[1..-1].each do |val|
+        if val
+          grouped << [val]
+        else
+          grouped.last << val
+        end
+      end
+      grouped.map { |items|
+        [[items.first, items.count], *[nil] * (items.count - 1)]
+      }.flatten(1)
     end
   end
 end

--- a/lib/daru/index.rb
+++ b/lib/daru/index.rb
@@ -401,7 +401,7 @@ module Daru
 
     private
 
-    # It is complicated, but the only algo I could think.
+    # It is complicated, but the only algo I could think of.
     # It does [:a, nil, nil, :b, nil, :c] # =>
     #         [[:a,3], nil, nil, [:b,2], nil, :c]
     # Needed by tuples_with_rowspans, which we need for pretty HTML
@@ -414,9 +414,9 @@ module Daru
           grouped.last << val
         end
       end
-      grouped.map { |items|
+      grouped.flat_map { |items|
         [[items.first, items.count], *[nil] * (items.count - 1)]
-      }.flatten(1)
+      }
     end
   end
 end

--- a/lib/daru/iruby/templates/dataframe.html.erb
+++ b/lib/daru/iruby/templates/dataframe.html.erb
@@ -1,6 +1,6 @@
 <table>
   <tr>
-    <th colspan='<%= @vectors.size+1 %>'>Daru::DataFrame:<%=object_id%> rows: <%=nrows%> cols: <%=ncols%></th>
+    <th colspan='<%= @vectors.size+1 %>'>Daru::DataFrame<%= name ? ": #{name} " : ''%>(<%=nrows%>x<%=ncols%>)</th>
   </tr>
   <tr>
     <th></th>
@@ -20,7 +20,9 @@
 
   <% if nrows > threshold %>
     <tr>
-      <%= '<td>...</td>' * (@vectors.size + 1) %>
+      <% (@vectors.size + 1).times do %>
+        <td>...</td>
+      <% end %>
     </tr>
 
     <% last_index = @index.to_a.last

--- a/lib/daru/iruby/templates/dataframe_mi.html.erb
+++ b/lib/daru/iruby/templates/dataframe_mi.html.erb
@@ -1,0 +1,45 @@
+<table>
+  <tr>
+    <th colspan='<%= @vectors.size+index.width %>'>Daru::DataFrame<%= name ? ": #{name} " : ''%>(<%=nrows%>x<%=ncols%>)</th>
+  </tr>
+  <tr>
+    <th colspan="<%= index.width %>"></th>
+    <% @vectors.each do |vector| %>
+      <th><%=vector%></th>
+    <% end %>
+  </tr>
+
+  <% @index.tuples_with_rowspans.first(threshold).zip(@index.to_a).each do |tuple, index| %>
+    <tr>
+      <% tuple.each do |idx, span| %>
+        <th rowspan="<%= span %>"><%= idx %></th>
+      <% end %>
+      <% row[index].each do |element| %>
+        <td><%= element.to_s %></td>
+      <% end %>
+    </tr>
+  <% end %>
+
+  <% if nrows > threshold %>
+    <tr>
+      <% index.width.times do %>
+        <th>...</th>
+      <% end %>
+      <% @vectors.size.times do %>
+        <td>...</td>
+      <% end %>
+    </tr>
+
+    <% last_index = @index.to_a.last
+       last_row = row[last_index] %>
+
+    <tr>
+      <% last_index.each do |idx| %>
+        <th><%= idx %></td>
+      <% end %>
+      <% last_row.each do |element| %>
+        <td><%= element.to_s %></td>
+      <% end %>
+    </tr>
+  <% end %>
+</table>

--- a/lib/daru/iruby/templates/multi_index.html.erb
+++ b/lib/daru/iruby/templates/multi_index.html.erb
@@ -1,0 +1,12 @@
+<table>
+  <tr>
+    <th colspan="<%= width %>">Daru::MultiIndex(<%= size %>x<%= width %>)</th>
+  </tr>
+  <% tuples_with_rowspans.each do |row| %>
+    <tr>
+      <% row.each do |val, span| %>
+        <th rowspan="<%= span %>"><%= val %></th>
+      <% end %>
+    </tr>
+  <% end %>
+</table>

--- a/lib/daru/iruby/templates/vector.html.erb
+++ b/lib/daru/iruby/templates/vector.html.erb
@@ -1,11 +1,13 @@
 <table>
   <tr>
-    <th colspan="2">Daru::Vector:<%= object_id %> size: <%= size %></th>
+    <th colspan="2">Daru::Vector(<%= size %>)</th>
   </tr>
-  <tr>
-      <th> </th>
-      <th><%= name || 'nil' %></th>
-  </tr>
+  <% if name %>
+    <tr>
+        <th> </th>
+        <th><%= name %></th>
+    </tr>
+  <% end %>
 
   <% @index.first(threshold).each do |index| %>
     <tr>

--- a/lib/daru/iruby/templates/vector_mi.html.erb
+++ b/lib/daru/iruby/templates/vector_mi.html.erb
@@ -1,0 +1,36 @@
+<table>
+  <tr>
+    <th colspan="<%= index.width+1 %>">Daru::Vector(<%= size %>)</th>
+  </tr>
+  <% if name %>
+    <tr>
+        <th colspan="<%= index.width %>"> </th>
+        <th><%= name %></th>
+    </tr>
+  <% end %>
+
+  <% @index.tuples_with_rowspans.first(threshold).zip(@data).each do |tuple, value| %>
+    <tr>
+      <% tuple.each do |idx, span| %>
+        <th rowspan="<%= span %>"><%= idx %></th>
+      <% end %>
+      <td><%= value %></td>
+    </tr>
+  <% end %>
+
+  <% if size > threshold %>
+    <% last_index = @index.to_a.last %>
+    <tr>
+      <% last_index.size.times do %>
+        <th>...</th>
+      <% end %>
+      <td>...</td>
+    </tr>
+    <tr>
+      <% last_index.each do |idx| %>
+        <th><%= idx %></td>
+      <% end %>
+      <td><%= self[last_index] %></td>
+    </tr>
+  <% end %>
+</table>

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -803,7 +803,11 @@ module Daru
 
     # Convert to html for iruby
     def to_html threshold=30
-      path = File.expand_path('../iruby/templates/vector.html.erb', __FILE__)
+      path = if index.is_a?(MultiIndex)
+               File.expand_path('../iruby/templates/vector_mi.html.erb', __FILE__)
+             else
+               File.expand_path('../iruby/templates/vector.html.erb', __FILE__)
+             end
       ERB.new(File.read(path).strip).result(binding)
     end
 

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -2771,19 +2771,28 @@ describe Daru::DataFrame do
   context '#to_html' do
     let(:doc) { Nokogiri::HTML(df.to_html) }
     subject(:table) { doc.at('table') }
+    let(:header) { table.at('tr:first-child > th:first-child') }
+    let(:name) { 'test' }
 
     context 'simple' do
-      let(:df) { Daru::DataFrame.new({a: [1,2,3], b: [3,4,5], c: [6,7,8]}, name: 'test')}
+      let(:df) { Daru::DataFrame.new({a: [1,2,3], b: [3,4,5], c: [6,7,8]}, name: name)}
 
       describe 'header' do
-        subject(:header) { table.at('tr:first-child > th:first-child') }
+        subject { header }
+
         it { is_expected.not_to be_nil }
         its(['colspan']) { is_expected.to eq (df.ncols + 1).to_s }
-        its(:text) { is_expected.to eq "Daru::DataFrame:#{df.object_id} rows: 3 cols: 3" }
+        its(:text) { is_expected.to eq "Daru::DataFrame: test (3x3)" }
+
+        context 'without name' do
+          let(:name) { nil }
+
+          its(:text) { is_expected.to eq "Daru::DataFrame(3x3)" }
+        end
       end
 
       describe 'column headers' do
-        subject(:name) { table.search('tr:nth-child(2) th').map(&:text) }
+        subject(:columns) { table.search('tr:nth-child(2) th').map(&:text) }
         its(:size) { is_expected.to eq df.ncols + 1 }
         it { is_expected.to eq ['', 'a', 'b', 'c'] }
       end
@@ -2806,6 +2815,12 @@ describe Daru::DataFrame do
 
     context 'large dataframe' do
       let(:df) { Daru::DataFrame.new({a: [1,2,3]*100, b: [3,4,5]*100, c: [6,7,8]*100}, name: 'test') }
+
+      describe 'header' do
+        subject { header }
+
+        its(:text) { is_expected.to eq "Daru::DataFrame: test (300x3)" }
+      end
 
       it 'has only 30 rows (+ 2 header rows, + 2 finishing rows)' do
         expect(table.search('tr').size).to eq 34

--- a/spec/index_spec.rb
+++ b/spec/index_spec.rb
@@ -339,7 +339,7 @@ describe Daru::MultiIndex do
     end
   end
 
-  context "inspect" do
+  context "#inspect" do
     context 'small index' do
       subject {
         Daru::MultiIndex.from_tuples [
@@ -514,6 +514,84 @@ describe Daru::MultiIndex do
             [:two,:bar]
           ])
       )
+    end
+  end
+
+  context 'other forms of tuple list representation' do
+    let(:index) {
+      Daru::MultiIndex.from_tuples [
+        [:a,:one,:bar],
+        [:a,:one,:baz],
+        [:a,:two,:bar],
+        [:a,:two,:baz],
+        [:b,:one,:bar],
+        [:b,:two,:bar],
+        [:b,:two,:baz],
+        [:b,:one,:foo],
+        [:c,:one,:bar],
+        [:c,:one,:baz],
+        [:c,:two,:foo],
+        [:c,:two,:bar]
+      ]
+    }
+
+    context '#sparse_tuples' do
+      subject { index.sparse_tuples }
+
+      it { is_expected.to eq [
+          [:a ,:one,:bar],
+          [nil, nil,:baz],
+          [nil,:two,:bar],
+          [nil, nil,:baz],
+          [:b ,:one,:bar],
+          [nil,:two,:bar],
+          [nil, nil,:baz],
+          [nil,:one,:foo],
+          [:c ,:one,:bar],
+          [nil, nil,:baz],
+          [nil,:two,:foo],
+          [nil, nil,:bar]
+      ]}
+    end
+
+    context '#tuples_with_rowspans' do
+      subject { index.tuples_with_rowspans }
+
+      it { is_expected.to eq [
+          [[:a,4],[:one,2],[:bar,1]],
+          [                [:baz,1]],
+          [       [:two,2],[:bar,1]],
+          [                [:baz,1]],
+          [[:b,4],[:one,1],[:bar,1]],
+          [       [:two,2],[:bar,1]],
+          [                [:baz,1]],
+          [       [:one,1],[:foo,1]],
+          [[:c,4],[:one,2],[:bar,1]],
+          [                [:baz,1]],
+          [       [:two,2],[:foo,1]],
+          [                [:bar,1]]
+      ]}
+    end
+
+    context '#to_html' do
+      let(:table) { Nokogiri::HTML(index.to_html) }
+
+      describe 'first row' do
+        subject { table.at('tr:first-child > th') }
+        its(['colspan']) { is_expected.to eq '3' }
+        its(:text) { is_expected.to eq 'Daru::MultiIndex(12x3)' }
+      end
+
+      describe 'next row' do
+        let(:row) { table.at('tr:nth-child(2)') }
+        subject { row.inner_html.scan(/<th.+?<\/th>/) }
+
+        it { is_expected.to eq [
+            '<th rowspan="4">a</th>',
+            '<th rowspan="2">one</th>',
+            '<th rowspan="1">bar</th>'
+        ]}
+      end
     end
   end
 end

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -1439,13 +1439,19 @@ describe Daru::Vector do
         subject(:header) { table.at('tr:first-child > th:first-child') }
         it { is_expected.not_to be_nil }
         its(['colspan']) { is_expected.to eq '2' }
-        its(:text) { is_expected.to eq "Daru::Vector:#{vector.object_id} size: 3" }
+        its(:text) { is_expected.to eq "Daru::Vector(3)" }
       end
 
       describe 'name' do
         subject(:name) { table.at('tr:nth-child(2) > th:nth-child(2)') }
         it { is_expected.not_to be_nil }
         its(:text) { is_expected.to eq 'test' }
+
+        context 'withought name' do
+          let(:vector) { Daru::Vector.new [1,nil,3], index: [:a, :b, :c] }
+
+          it { is_expected.to be_nil }
+        end
       end
 
       describe 'index' do

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -1430,13 +1430,14 @@ describe Daru::Vector do
   context '#to_html' do
     let(:doc) { Nokogiri::HTML(vector.to_html) }
     subject(:table) { doc.at('table') }
+    let(:header) { table.at('tr:first-child > th:first-child') }
 
     context 'simple' do
       let(:vector) { Daru::Vector.new [1,nil,3], index: [:a, :b, :c], name: 'test' }
       it { is_expected.not_to be_nil }
 
       describe 'header' do
-        subject(:header) { table.at('tr:first-child > th:first-child') }
+        subject { header }
         it { is_expected.not_to be_nil }
         its(['colspan']) { is_expected.to eq '2' }
         its(:text) { is_expected.to eq "Daru::Vector(3)" }
@@ -1483,6 +1484,47 @@ describe Daru::Vector do
         subject(:row) { table.search('tr:nth-child(34) td').map(&:text) }
         its(:count) { is_expected.to eq 2 }
         it { is_expected.to eq ['299', '3'] }
+      end
+    end
+
+    context 'multi-index' do
+      subject(:vector) {
+        Daru::Vector.new(
+          [1,2,3,4,5,6,7],
+          name: 'test',
+          index: Daru::MultiIndex.from_tuples([
+              %w[foo one],
+              %w[foo two],
+              %w[foo three],
+              %w[bar one],
+              %w[bar two],
+              %w[bar three],
+              %w[baz one],
+           ]),
+        )
+      }
+
+      describe 'header' do
+        subject { header }
+        it { is_expected.not_to be_nil }
+        its(['colspan']) { is_expected.to eq '3' }
+        its(:text) { is_expected.to eq "Daru::Vector(7)" }
+      end
+
+      describe 'name row' do
+        subject(:row) { table.at('tr:nth-child(2)').search('th') }
+        its(:count) { should == 2 }
+        it { expect(row.first['colspan']).to eq '2' }
+      end
+
+      describe 'first data row' do
+        let(:row) { table.at('tr:nth-child(3)') }
+        subject { row.inner_html.scan(/<t[dh].+?<\/t[dh]>/) }
+        it { is_expected.to eq [
+          '<th rowspan="3">foo</th>',
+          '<th rowspan="1">one</th>',
+          '<td>1</td>'
+        ]}
       end
     end
   end


### PR DESCRIPTION
Changes in the same fashion I did for `#inspect`. Mostly cosmetic, but data with multi indexes are now much more readable (for me, and may be only for me :)).

Before:
![](http://storage5.static.itmages.com/i/16/0601/h_1464799668_9347446_66530df6ae.png)

After:
![](http://storage6.static.itmages.com/i/16/0601/h_1464799734_5421739_bbd88bcc1e.png)

(Still nothing done about multi-index dataframes using `MultiIndex` as order, though.)