### PR TITLE
Remove monkey-patching

### DIFF
--- a/lib/daru.rb
+++ b/lib/daru.rb
@@ -69,10 +69,12 @@ autoload :Spreadsheet, 'spreadsheet'
 autoload :CSV, 'csv'
 
 require 'matrix'
-require 'securerandom'
+#require 'securerandom'
 require 'reportbuilder'
 
 require 'daru/version.rb'
+
+require 'daru/helpers/array.rb'
 require 'daru/index.rb'
 require 'daru/vector.rb'
 require 'daru/dataframe.rb'

--- a/lib/daru.rb
+++ b/lib/daru.rb
@@ -69,7 +69,6 @@ autoload :Spreadsheet, 'spreadsheet'
 autoload :CSV, 'csv'
 
 require 'matrix'
-#require 'securerandom'
 require 'reportbuilder'
 
 require 'daru/version.rb'

--- a/lib/daru/date_time/index.rb
+++ b/lib/daru/date_time/index.rb
@@ -216,7 +216,7 @@ module Daru
     Helper = DateTimeIndexHelper
 
     def self.try_create(source)
-      if source && source.is_a?(Array) && source.all_are?(DateTime)
+      if source && ArrayHelper.array_of?(source, DateTime)
         new(source, freq: :infer)
       else
         nil

--- a/lib/daru/helpers/array.rb
+++ b/lib/daru/helpers/array.rb
@@ -1,0 +1,39 @@
+module Daru
+  module ArrayHelper
+    module_function
+
+    # Recode repeated values on an array, adding the number of repetition
+    # at the end
+    # Example:
+    #   a=%w{a b c c d d d e}
+    #   a.recode_repeated
+    #   => ["a","b","c_1","c_2","d_1","d_2","d_3","e"]
+    def recode_repeated(array)
+      return array if array.size == array.uniq.size
+
+      # create hash of { <name> => 0}
+      # for all names which are more than one time in array
+      counter = array
+                .group_by(&:itself)
+                .select { |_, g| g.size > 1 }
+                .map(&:first)
+                .collect { |n| [n, 0] }.to_h
+
+      # ...and use this hash for actual recode
+      array.collect do |n|
+        if counter.key?(n)
+          counter[n] += 1
+          '%s_%d' % [n, counter[n]]
+        else
+          n
+        end
+      end
+    end
+
+    def array_of?(array, match)
+      array.is_a?(Array) &&
+        !array.empty? &&
+        array.all? { |el| match === el }
+    end
+  end
+end

--- a/lib/daru/helpers/array.rb
+++ b/lib/daru/helpers/array.rb
@@ -33,7 +33,7 @@ module Daru
     def array_of?(array, match)
       array.is_a?(Array) &&
         !array.empty? &&
-        array.all? { |el| match === el }
+        array.all? { |el| match === el } # rubocop:disable Style/CaseEquality
     end
   end
 end

--- a/lib/daru/io/io.rb
+++ b/lib/daru/io/io.rb
@@ -9,11 +9,25 @@ module Daru
             # data is splitted by `\s+` -- there is no chance that
             # "empty" (currently just '') will be between data?..
             nil
-          elsif c.is_a?(String) && c.is_number?
-            c =~ /^\d+$/ ? c.to_i : c.tr(',','.').to_f
           else
-            c
+            try_string_to_number(c)
           end
+        end
+      end
+
+      private
+
+      INT_PATTERN = /^[-+]?\d+$/
+      FLOAT_PATTERN = /^[-+]?\d+[,.]?\d*(e-?\d+)?$/
+
+      def try_string_to_number(s)
+        case s
+        when INT_PATTERN
+          s.to_i
+        when FLOAT_PATTERN
+          s.tr(',', '.').to_f
+        else
+          s
         end
       end
     end
@@ -31,7 +45,7 @@ module Daru
         worksheet_id = opts[:worksheet_id]
         book         = Spreadsheet.open path
         worksheet    = book.worksheet worksheet_id
-        headers      = worksheet.row(0).recode_repeated.map(&:to_sym)
+        headers      = ArrayHelper.recode_repeated(worksheet.row(0)).map(&:to_sym)
 
         df = Daru::DataFrame.new({})
         headers.each_with_index do |h,i|
@@ -202,7 +216,7 @@ module Daru
           .tap { |c| yield c if block_given? }
           .to_a
 
-        headers       = csv_as_arrays.shift.recode_repeated.map
+        headers       = ArrayHelper.recode_repeated(csv_as_arrays.shift)
         csv_as_arrays = csv_as_arrays.transpose
 
         headers.each_with_index.map { |h, i| [h, csv_as_arrays[i]] }.to_h

--- a/lib/daru/maths/statistics/vector.rb
+++ b/lib/daru/maths/statistics/vector.rb
@@ -59,7 +59,7 @@ module Daru
         end
 
         def sum_of_squared_deviation
-          (@data.inject(0) { |a,x| x.square + a } - sum.square.quo(n_valid).to_f).to_f
+          (@data.inject(0) { |a,x| x**2 + a } - (sum**2).quo(n_valid).to_f).to_f
         end
 
         # Retrieve unique values of non-nil data

--- a/lib/daru/monkeys.rb
+++ b/lib/daru/monkeys.rb
@@ -1,31 +1,4 @@
 class Array
-  # Recode repeated values on an array, adding the number of repetition
-  # at the end
-  # Example:
-  #   a=%w{a b c c d d d e}
-  #   a.recode_repeated
-  #   => ["a","b","c_1","c_2","d_1","d_2","d_3","e"]
-  def recode_repeated
-    return self if size == uniq.size
-
-    # create hash of { <name> => 0}
-    # for all names which are more than one time in array
-    counter = group_by(&:itself)
-              .select { |_, g| g.size > 1 }
-              .map(&:first)
-              .collect { |n| [n, 0] }.to_h
-
-    # ...and use this hash for actual recode
-    collect do |n|
-      if counter.key?(n)
-        counter[n] += 1
-        '%s_%d' % [n, counter[n]]
-      else
-        n
-      end
-    end
-  end
-
   def daru_vector name=nil, index=nil, dtype=:array
     Daru::Vector.new self, name: name, index: index, dtype: dtype
   end
@@ -34,14 +7,6 @@ class Array
 
   def to_index
     Daru::Index.new self
-  end
-
-  def all_are?(match)
-    !empty? && grep(match).size == size
-  end
-
-  def single_class?
-    map(&:class).uniq.size == 1
   end
 end
 
@@ -81,27 +46,12 @@ class MDArray
 
   alias_method :dv, :daru_vector
 end
-# :nocov:
-
-class Numeric
-  def square
-    self * self
-  end
-end
 
 class Matrix
   def elementwise_division other
     map.with_index do |e, index|
       e / other.to_a.flatten[index]
     end
-  end
-end
-
-class String
-  NUMBER_PATTERN = /^-?\d+[,.]?\d*(e-?\d+)?$/
-
-  def is_number?
-    !!self =~ NUMBER_PATTERN
   end
 end
 
@@ -119,3 +69,4 @@ module Daru
     alias :to_hash :to_h
   end
 end
+# :nocov:

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -1,0 +1,8 @@
+describe Daru::ArrayHelper do
+  context '#recode_repeated' do
+    let(:source) { [1,'a',1,'a','b',:c,2] }
+    subject { described_class.recode_repeated(source) }
+
+    it { is_expected.to eq ['1_1','a_1', '1_2','a_2','b',:c,2] }
+  end
+end

--- a/spec/monkeys_spec.rb
+++ b/spec/monkeys_spec.rb
@@ -1,11 +1,4 @@
 describe "Monkeys" do
-  context Array do
-    it "#recode_repeated" do
-      expect([1,'a',1,'a','b',:c,2].recode_repeated).to eq(
-        ['1_1','a_1', '1_2','a_2','b',:c,2])
-    end
-  end
-
   context Matrix do
     it "performs elementwise division" do
       left  = Matrix[[3,6,9],[4,8,12],[2,4,6]]


### PR DESCRIPTION
Monkey-patching of core Ruby classes is a questionable practice that could be argued about.
But monkey-patching in gems for gem's internal needs (which, nevertheless, pollutes all the outside code) is definitely bad. So, let's get rid of this.

**Notes**
What was left in `monkeys.rb`:
* ability to convert core classes to `Daru::{Vector,DataFrame}` (though, I feel like it should be in optional `require 'daru/shortcuts'` or `daru/extensions`)
* `Object#itself` (it is introduced in Ruby 2.2, but somehow not in backports)
* `Matrix#elementwise_division` (I am afraid to break something by moving it)

The most painful was moving of `Array`s extensions (`recode_repeated` and `all_are?`), the code became not that pretty as it was... But we just should do it, anyways.