### PR TITLE
re assign base category after deleted using remove used categories

### DIFF
--- a/lib/daru/category.rb
+++ b/lib/daru/category.rb
@@ -329,7 +329,6 @@ module Daru
       validate_categories(cat_with_order)
       add_extra_categories(cat_with_order - categories)
       order_with cat_with_order
-      self.base_category = cat_with_order.first
     end
 
     # Rename categories.

--- a/lib/daru/category.rb
+++ b/lib/daru/category.rb
@@ -7,6 +7,7 @@ module Daru
     attr_reader :array, :cat_hash, :map_int_cat
 
     # Initializes a vector to store categorical data.
+    # @note Base category is set to the first category encountered in the vector.
     # @param [Array] data the categorical data
     # @param [Hash] opts the options
     # @option opts [Boolean] :ordered true if data is ordered, false otherwise
@@ -355,11 +356,25 @@ module Daru
       self
     end
 
+    # Removes the unused categories
+    # @note If base category is removed, then the first occuring category in the
+    #   data is taken as base category. Order of the undeleted categories
+    #   remains preserved.
+    # @return [Daru::Vector] Makes changes in the vector itself i.e. deletes
+    #   the unused categories and returns itself
+    # @example
+    #   dv = Daru::Vector.new [:one, :two, :one], type: :category,
+    #     categories: [:three, :two, :one]
+    #   dv.remove_unused_categories
+    #   dv.categories
+    #   # => [:two, :one]
     def remove_unused_categories
       old_categories = categories
 
       initialize_core_attributes to_a
       self.categories = old_categories & categories
+      self.base_category = @cat_hash.keys.first unless
+        categories.include? base_category
       self
     end
 

--- a/spec/categorical_spec.rb
+++ b/spec/categorical_spec.rb
@@ -340,7 +340,7 @@ describe Daru::Vector, "categorical" do
       its(:type) { is_expected.to eq :category }
       its(:categories) { is_expected.to eq [:c, :b, :a, 1] }
       its(:to_a) { is_expected.to eq [:a, 1, :a, 1, :c] }
-      its(:base_category) { is_expected.to eq :c }
+      its(:base_category) { is_expected.to eq :a }
     end
     
     context "incomplete" do

--- a/spec/categorical_spec.rb
+++ b/spec/categorical_spec.rb
@@ -229,14 +229,33 @@ describe Daru::Vector, "categorical" do
   end
   
   context '#remove_unused_categories' do
-    let(:dv) { Daru::Vector.new [:a, 1, :a, 1, :c], type: :category }
-    before do
-      dv.categories = [:a, :b, :c, 1]
-      dv.remove_unused_categories
+    context 'base category not removed' do
+      let(:dv) { Daru::Vector.new [:a, 1, :a, 1, :c], type: :category }
+      before do
+        dv.categories = [:a, :b, :c, 1]
+        dv.base_category = 1
+        dv.remove_unused_categories
+      end
+      subject { dv }
+      
+      its(:categories) { is_expected.to eq [:a, :c, 1] }
+      its(:to_a) { is_expected.to eq [:a, 1, :a, 1, :c] }
+      its(:base_category) { is_expected.to eq 1 }
     end
-    subject { dv }
-    
-    its(:categories) { is_expected.to eq [:a, :c, 1] }
+
+    context 'base category removed' do
+      let(:dv) { Daru::Vector.new [:a, 1, :a, 1, :c], type: :category }
+      before do
+        dv.categories = [:a, :b, :c, 1]
+        dv.base_category = :b
+        dv.remove_unused_categories
+      end
+      subject { dv }
+
+      its(:to_a) { is_expected.to eq [:a, 1, :a, 1, :c] }
+      its(:categories) { is_expected.to eq [:a, :c, 1] }
+      its(:base_category) { is_expected.to eq :a }
+    end
   end
   
   context "count" do


### PR DESCRIPTION
Fixes #188 

Although there was already `remove_unused_categories` method, I have added documentation for this method in this PR and made sure that a valid base category is assigned after its deleted.