### PR TITLE
Fix mistakes in #163

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ While preparing your pull requests, don't forget to check your code with Rubocop
 Daru has automatic testing with Guard. Just execute the following code before you start editting a file and any change you make will trigger the appropriate tests-
 
 ```
-guard rspec
+guard
 ```
 
 **NOTE**: Please make sure that you place test for your file at the same level and with same itermediatary directories. For example if code file lies in `lib/xyz/abc.rb` then its corresponding test should lie in `spec/xyz/abc_spec.rb`. This is to ensure correct working of Guard.

--- a/lib/daru/index/categorical_index.rb
+++ b/lib/daru/index/categorical_index.rb
@@ -1,5 +1,3 @@
-require 'spec_helper.rb'
-
 module Daru
   class CategoricalIndex < Index
     # Create a categorical index object.


### PR DESCRIPTION
In #163 by mistake I committed the following errors:

- Mentioned `guard rspec` in CONTRIBUTING.md but `guard rspec` doesn't work. Instead `guard` commands works.
- Wrote require 'spec_helper.rb' in categorical_index.rb which is preventing rake pry to work.