### PR TITLE
Remove Daru::DataFrame implicit hash method

### DIFF
--- a/lib/daru/monkeys.rb
+++ b/lib/daru/monkeys.rb
@@ -62,11 +62,4 @@ class Object
     end
   end
 end
-
-module Daru
-  class DataFrame
-    # NOTE: This alias will soon be removed. Use to_h in all future work.
-    alias :to_hash :to_h
-  end
-end
 # :nocov:


### PR DESCRIPTION
Daru DataFrames are not hashes and having an implicit converter can
introduce side effects when used with core Ruby classes that perform
implicit hash conversion.