### PR TITLE
[ci skip] Fix the position of documents

### DIFF
--- a/lib/daru/date_time/offsets.rb
+++ b/lib/daru/date_time/offsets.rb
@@ -82,6 +82,11 @@ module Daru
 
   module Offsets
     class DateOffsetType < DateOffset
+      # @method initialize
+      # Initialize one of the subclasses of DateOffsetType with the number of the times
+      # the offset should be applied, which is the supplied as the argument.
+      #
+      # @param n [Integer] The number of times an offset should be applied.
       def initialize n=1
         @n = n
       end
@@ -95,12 +100,6 @@ module Daru
     # @abstract
     # @private
     class Tick < DateOffsetType
-      # @method initialize
-      # Initialize one of the subclasses of Tick with the number of the times
-      # the offset should be applied, which is the supplied as the argument.
-      #
-      # @param n [Integer] The number of times an offset should be applied.
-
       def + date_time
         date_time + @n*multiplier
       end


### PR DESCRIPTION
Fix the position of documents about `#initialize`.
This mismatch has existed from
760fb19d5e65e1e4231777fdb18f8fd4284b6e79 commit.