### PR TITLE
Display size of an argument instead of `self.index.size`

### DIFF
--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -991,7 +991,7 @@ module Daru
 
     def index= idx
       raise ArgumentError,
-        "Size of supplied index #{index.size} does not match size of DataFrame" if
+        "Size of supplied index #{idx.size} does not match size of DataFrame" if
         idx.size != size
       raise ArgumentError, 'Can only assign type Index and its subclasses.' unless
         idx.is_a?(Daru::Index)

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -1182,7 +1182,7 @@ describe Daru::Vector do
         it "raises error for index size != vector size" do
           expect {
             @vector.index = Daru::Index.new([4,2,6])
-          }.to raise_error
+          }.to raise_error(ArgumentError, "Size of supplied index 3 does not match size of DataFrame")
         end
       end
 


### PR DESCRIPTION
`index` of `#{index.size}` is an instance variable of
`Vector`. In this context displaying size of an argument
is more useful.