### PR TITLE
add reorder method to reorder vectors in dataframe

### DIFF
--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -973,6 +973,12 @@ module Daru
 
       Daru::Vector.new a, index: @index
     end
+    
+    def order=(order_array)
+      raise ArgumentError, 'Invalid order' unless
+        order_array.sort == vectors.to_a.sort
+      initialize(to_h, order: order_array)
+    end
 
     # Returns a vector, based on a string with a calculation based
     # on vector.

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -973,7 +973,21 @@ module Daru
 
       Daru::Vector.new a, index: @index
     end
-    
+
+    # Reorder the vectors in a dataframe
+    # @param [Array] order_array new order of the vectors
+    # @example
+    #   df = Daru::DataFrame({
+    #     a: [1, 2, 3],
+    #     b: [4, 5, 6]
+    #   }, order: [:a, :b])
+    #   df.order = [:b, :a]
+    #   df
+    #   # => #<Daru::DataFrame(3x2)>
+    #   #       b   a
+    #   #   0   4   1
+    #   #   1   5   2
+    #   #   2   6   3
     def order=(order_array)
       raise ArgumentError, 'Invalid order' unless
         order_array.sort == vectors.to_a.sort

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -2514,6 +2514,32 @@ describe Daru::DataFrame do
       expect(@df.index).to eq Daru::Index.new (1..5).to_a
     end
   end
+  
+  context '#order=' do
+    let(:df) do
+      Daru::DataFrame.new({
+        a: [1, 2, 3],
+        b: [4, 5, 6]
+      }, order: [:a, :b])
+    end
+    
+    context 'correct order' do
+      before { df.order = [:b, :a] }
+      subject { df }
+      
+      its(:'vectors.to_a') { is_expected.to eq [:b, :a] }
+      its(:'b.to_a') { is_expected.to eq [4, 5, 6] }
+      its(:'a.to_a') { is_expected.to eq [1, 2, 3] }
+    end
+    
+    context 'insufficient vectors' do
+      it { expect { df.order = [:a] }.to raise_error }
+    end
+    
+    context 'wrong vectors' do
+      it { expect { df.order = [:a, :b, 'b'] }.to raise_error }
+    end
+  end
 
   context "#vectors=" do
     before :each do


### PR DESCRIPTION
Fixes #245 

Add `order=` method to reorder vectors in a dataframe.