### PR TITLE
261 - Resolve a bug with false values on dataframe create

### DIFF
--- a/lib/daru/core/merge.rb
+++ b/lib/daru/core/merge.rb
@@ -78,7 +78,7 @@ module Daru
       end
 
       def sanitize_merge_keys(merge_keys)
-        merge_keys.map { |v| v || NilSorter.new }
+        merge_keys.map { |v| v.nil? ? NilSorter.new : v }
       end
 
       def df_to_a df

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -2288,7 +2288,7 @@ module Daru
       @index = Daru::Index.new(index || source.size)
 
       @data = @vectors.map do |name|
-        v = source.map { |h| h[name] || h[name.to_s] }
+        v = source.map { |h| h.fetch(name) { h[name.to_s] } }
         Daru::Vector.new(v, name: coerce_name(name), index: @index)
       end
     end

--- a/spec/core/merge_spec.rb
+++ b/spec/core/merge_spec.rb
@@ -141,6 +141,19 @@ describe Daru::DataFrame do
       expect(@left.join(@right, how: :right, on: [:name])).to eq(answer)
     end
 
+    it "doesn't convert false into nil when joining boolean values" do
+      left = Daru::DataFrame.new({ key: [1,2,3], left_value: [true, false, true] })
+      right = Daru::DataFrame.new({ key: [1,2,3], right_value: [true, false, true] })
+
+      answer = Daru::DataFrame.new({
+        left_value: [true, false, true],
+        key: [1,2,3],
+        right_value: [true, false, true]
+      }, order: [:left_value, :key, :right_value] )
+
+      expect(left.join(right, on: [:key], how: :inner)).to eq answer
+    end
+
     it "raises if :on field are absent in one of dataframes" do
       @right.vectors = [:id, :other_name]
       expect { @left.join(@right, how: :right, on: [:name]) }.to \

--- a/spec/dataframe_spec.rb
+++ b/spec/dataframe_spec.rb
@@ -177,14 +177,14 @@ describe Daru::DataFrame do
       end
 
       it "initializes from an Array of Hashes" do
-        df = Daru::DataFrame.new([{a: 1, b: 11}, {a: 2, b: 12}, {a: 3, b: 13},
+        df = Daru::DataFrame.new([{a: 1, b: 11}, {a: false, b: 12}, {a: 3, b: 13},
           {a: 4, b: 14}, {a: 5, b: 15}], order: [:b, :a],
           index: [:one, :two, :three, :four, :five])
 
         expect(df.index)  .to eq(Daru::Index.new [:one, :two, :three, :four, :five])
         expect(df.vectors).to eq(Daru::Index.new [:b, :a])
         expect(df.a.class).to eq(Daru::Vector)
-        expect(df.a)      .to eq([1,2,3,4,5].dv(:a,[:one, :two, :three, :four, :five]))
+        expect(df.a)      .to eq([1,false,3,4,5].dv(:a,[:one, :two, :three, :four, :five]))
       end
 
       it "initializes from Array of Arrays" do


### PR DESCRIPTION
This resolves #261.  The core issue was that creating a
dataframe from an array of hashes wasn't working properly
when some of the values were `false`.