### PR TITLE
correct the behavior of Vector#reorder! method

### DIFF
--- a/lib/daru/accessors/gsl_wrapper.rb
+++ b/lib/daru/accessors/gsl_wrapper.rb
@@ -1,122 +1,124 @@
-module Daru
-  module Accessors
-    module GSLStatistics
-      def vector_standardized_compute(m,sd)
-        Daru::Vector.new @data.collect { |x| (x.to_f - m).quo(sd) }, dtype: :gsl,
-                                                                     index: @context.index, name: @context.name
-      end
+if Daru.has_gsl?
+  module Daru
+    module Accessors
+      module GSLStatistics
+        def vector_standardized_compute(m,sd)
+          Daru::Vector.new @data.collect { |x| (x.to_f - m).quo(sd) }, dtype: :gsl,
+                                                                       index: @context.index, name: @context.name
+        end
 
-      def vector_centered_compute(m)
-        Daru::Vector.new @data.collect { |x| (x.to_f - m) }, dtype: :gsl,
-                                                             index: @context.index, name: @context.name
-      end
+        def vector_centered_compute(m)
+          Daru::Vector.new @data.collect { |x| (x.to_f - m) }, dtype: :gsl,
+                                                               index: @context.index, name: @context.name
+        end
 
-      def sample_with_replacement(sample=1)
-        r = GSL::Rng.alloc(GSL::Rng::MT19937,rand(10_000))
-        Daru::Vector.new(r.sample(@data, sample).to_a, dtype: :gsl,
-                                                       index: @context.index, name: @context.name)
-      end
+        def sample_with_replacement(sample=1)
+          r = GSL::Rng.alloc(GSL::Rng::MT19937,rand(10_000))
+          Daru::Vector.new(r.sample(@data, sample).to_a, dtype: :gsl,
+                                                         index: @context.index, name: @context.name)
+        end
 
-      def sample_without_replacement(sample=1)
-        r = GSL::Rng.alloc(GSL::Rng::MT19937,rand(10_000))
-        r.choose(@data, sample).to_a
-      end
+        def sample_without_replacement(sample=1)
+          r = GSL::Rng.alloc(GSL::Rng::MT19937,rand(10_000))
+          r.choose(@data, sample).to_a
+        end
 
-      def median
-        GSL::Stats.median_from_sorted_data(@data.sort)
-      end
+        def median
+          GSL::Stats.median_from_sorted_data(@data.sort)
+        end
 
-      def variance_sample(m)
-        @data.variance(m)
-      end
+        def variance_sample(m)
+          @data.variance(m)
+        end
 
-      def standard_deviation_sample(m)
-        @data.sd(m)
-      end
+        def standard_deviation_sample(m)
+          @data.sd(m)
+        end
 
-      def variance_population(m)
-        @data.variance_with_fixed_mean(m)
-      end
+        def variance_population(m)
+          @data.variance_with_fixed_mean(m)
+        end
 
-      def standard_deviation_population m
-        @data.sd_with_fixed_mean(m)
-      end
+        def standard_deviation_population m
+          @data.sd_with_fixed_mean(m)
+        end
 
-      def skew
-        @data.skew
-      end
+        def skew
+          @data.skew
+        end
 
-      def kurtosis
-        @data.kurtosis
-      end
-    end
-
-    class GSLWrapper
-      include Enumerable
-      extend Forwardable
-      include Daru::Accessors::GSLStatistics
-
-      def_delegators :@data, :[], :size, :to_a, :each
-
-      attr_reader :data
-
-      def compact
-        ::GSL::Vector.alloc(@data.to_a - [Float::NAN])
-      end
-
-      [:mean, :min, :max, :prod, :sum].each do |method|
-        define_method(method) do
-          compact.send(method.to_sym) rescue nil
+        def kurtosis
+          @data.kurtosis
         end
       end
 
-      alias :product :prod
+      class GSLWrapper
+        include Enumerable
+        extend Forwardable
+        include Daru::Accessors::GSLStatistics
 
-      def each(&block)
-        @data.each(&block)
-        self
-      end
+        def_delegators :@data, :[], :size, :to_a, :each
 
-      def map!(&block)
-        @data.map!(&block)
-        self
-      end
+        attr_reader :data
 
-      def initialize data, context
-        @data = ::GSL::Vector.alloc(data)
-        @context = context
-      end
-
-      def []= index, element
-        if index == size
-          push element
-        else
-          @data[index] = element
+        def compact
+          ::GSL::Vector.alloc(@data.to_a - [Float::NAN])
         end
-      end
 
-      def delete_at index
-        @data.delete_at index
-      end
+        [:mean, :min, :max, :prod, :sum].each do |method|
+          define_method(method) do
+            compact.send(method.to_sym) rescue nil
+          end
+        end
 
-      def index key
-        @data.to_a.index key
-      end
+        alias :product :prod
 
-      def push value
-        @data = @data.concat value
-        self
-      end
-      alias :<< :push
-      alias :concat :push
+        def each(&block)
+          @data.each(&block)
+          self
+        end
 
-      def dup
-        GSLWrapper.new(@data.to_a, @context)
-      end
+        def map!(&block)
+          @data.map!(&block)
+          self
+        end
 
-      def == other
-        @data == other.data
+        def initialize data, context
+          @data = ::GSL::Vector.alloc(data)
+          @context = context
+        end
+
+        def []= index, element
+          if index == size
+            push element
+          else
+            @data[index] = element
+          end
+        end
+
+        def delete_at index
+          @data.delete_at index
+        end
+
+        def index key
+          @data.to_a.index key
+        end
+
+        def push value
+          @data = @data.concat value
+          self
+        end
+        alias :<< :push
+        alias :concat :push
+
+        def dup
+          GSLWrapper.new(@data.to_a, @context)
+        end
+
+        def == other
+          @data == other.data
+        end
       end
     end
   end
-end if Daru.has_gsl?
+end

--- a/lib/daru/accessors/nmatrix_wrapper.rb
+++ b/lib/daru/accessors/nmatrix_wrapper.rb
@@ -1,110 +1,112 @@
-module Daru
-  module Accessors
-    # Internal class for wrapping NMatrix
-    class NMatrixWrapper
-      include Enumerable
+if Daru.has_nmatrix?
+  module Daru
+    module Accessors
+      # Internal class for wrapping NMatrix
+      class NMatrixWrapper
+        include Enumerable
 
-      def each(&block)
-        @data[0...@size].each(&block)
-        self
+        def each(&block)
+          @data[0...@size].each(&block)
+          self
+        end
+
+        def map!(&block)
+          @data = NMatrix.new [@size*2], map(&block).to_a, dtype: nm_dtype
+          self
+        end
+
+        # :nocov:
+        # FIXME: not sure, why this kind of wrapper have such a pure coverage
+        def inject(*args, &block)
+          @data[0...@size].inject(*args, &block)
+        end
+        # :nocov:
+
+        attr_reader :size, :data, :nm_dtype
+
+        def initialize vector, context, nm_dtype=:int32
+          @size = vector.size
+          @data = NMatrix.new [@size*2], vector.to_a, dtype: nm_dtype
+          @context = context
+          @nm_dtype = @data.dtype
+          # init with twice the storage for reducing the need to resize
+        end
+
+        def [] *index
+          return @data[*index] if index[0] < @size
+          nil
+        end
+
+        def []= index, value
+          raise ArgumentError, "Index #{index} does not exist" if
+            index > @size && index < @data.size
+          resize     if index >= @data.size
+          @size += 1 if index == @size
+
+          @data = @data.cast(dtype: :object) if value.nil?
+          @data[index] = value
+        end
+
+        # :nocov:
+        def == other
+          @data[0...@size] == other[0...@size] and @size == other.size
+        end
+        # :nocov:
+
+        def delete_at index
+          arry = @data.to_a
+          arry.delete_at index
+          @data = NMatrix.new [(2*@size-1)], arry, dtype: @nm_dtype
+          @size -= 1
+        end
+
+        def index key
+          @data.to_a.index key
+        end
+
+        # :nocov:
+        def << element
+          resize if @size >= @data.size
+          self[@size] = element
+        end
+        # :nocov:
+
+        def to_a
+          @data[0...@size].to_a
+        end
+
+        def dup
+          NMatrixWrapper.new @data[0...@size].to_a, @context, @nm_dtype
+        end
+
+        def resize size=@size*2
+          raise ArgumentError, 'Size must be greater than current size' if size < @size
+
+          @data = NMatrix.new [size], @data.to_a, dtype: @nm_dtype
+        end
+
+        # :nocov:
+        def mean
+          @data[0...@size].mean.first
+        end
+
+        def product
+          @data[0...@size].inject(1) { |m,e| m*e }
+        end
+
+        def sum
+          @data[0...@size].inject(:+)
+        end
+
+        def max
+          @data[0...@size].max
+        end
+
+        def min
+          @data[0...@size].min
+        end
+        # :nocov:
       end
-
-      def map!(&block)
-        @data = NMatrix.new [@size*2], map(&block).to_a, dtype: nm_dtype
-        self
-      end
-
-      # :nocov:
-      # FIXME: not sure, why this kind of wrapper have such a pure coverage
-      def inject(*args, &block)
-        @data[0...@size].inject(*args, &block)
-      end
-      # :nocov:
-
-      attr_reader :size, :data, :nm_dtype
-
-      def initialize vector, context, nm_dtype=:int32
-        @size = vector.size
-        @data = NMatrix.new [@size*2], vector.to_a, dtype: nm_dtype
-        @context = context
-        @nm_dtype = @data.dtype
-        # init with twice the storage for reducing the need to resize
-      end
-
-      def [] *index
-        return @data[*index] if index[0] < @size
-        nil
-      end
-
-      def []= index, value
-        raise ArgumentError, "Index #{index} does not exist" if
-          index > @size && index < @data.size
-        resize     if index >= @data.size
-        @size += 1 if index == @size
-
-        @data = @data.cast(dtype: :object) if value.nil?
-        @data[index] = value
-      end
-
-      # :nocov:
-      def == other
-        @data[0...@size] == other[0...@size] and @size == other.size
-      end
-      # :nocov:
-
-      def delete_at index
-        arry = @data.to_a
-        arry.delete_at index
-        @data = NMatrix.new [(2*@size-1)], arry, dtype: @nm_dtype
-        @size -= 1
-      end
-
-      def index key
-        @data.to_a.index key
-      end
-
-      # :nocov:
-      def << element
-        resize if @size >= @data.size
-        self[@size] = element
-      end
-      # :nocov:
-
-      def to_a
-        @data[0...@size].to_a
-      end
-
-      def dup
-        NMatrixWrapper.new @data[0...@size].to_a, @context, @nm_dtype
-      end
-
-      def resize size=@size*2
-        raise ArgumentError, 'Size must be greater than current size' if size < @size
-
-        @data = NMatrix.new [size], @data.to_a, dtype: @nm_dtype
-      end
-
-      # :nocov:
-      def mean
-        @data[0...@size].mean.first
-      end
-
-      def product
-        @data[0...@size].inject(1) { |m,e| m*e }
-      end
-
-      def sum
-        @data[0...@size].inject(:+)
-      end
-
-      def max
-        @data[0...@size].max
-      end
-
-      def min
-        @data[0...@size].min
-      end
-      # :nocov:
     end
   end
-end if Daru.has_nmatrix?
+end

--- a/lib/daru/category.rb
+++ b/lib/daru/category.rb
@@ -61,9 +61,11 @@ module Daru
       case lib
       when :gruff, :nyaplot
         @plotting_library = lib
-        extend Module.const_get(
-          "Daru::Plotting::Category::#{lib.to_s.capitalize}Library"
-        ) if Daru.send("has_#{lib}?".to_sym)
+        if Daru.send("has_#{lib}?".to_sym)
+          extend Module.const_get(
+            "Daru::Plotting::Category::#{lib.to_s.capitalize}Library"
+          )
+        end
       else
         raise ArgumentError, "Plotting library #{lib} not supported. "\
           'Supported libraries are :nyaplot and :gruff'
@@ -772,9 +774,10 @@ module Daru
 
     def assert_ordered operation
       # TODO: Change ArgumentError to something more expressive
+      return if ordered?
+
       raise ArgumentError, "Can not apply #{operation} when vector is unordered. "\
         'To make the categorical data ordered, use #ordered = true'\
-        unless ordered?
     end
 
     def dummy_coding full
@@ -897,14 +900,17 @@ module Daru
 
     def validate_index index
       # Change to SizeError
+      return unless size != index.size
+
       raise ArgumentError, "Size of index (#{index.size}) does not matches"\
-        "size of vector (#{size})" if size != index.size
+        "size of vector (#{size})"
     end
 
     def modify_category_at pos, category
-      raise ArgumentError, "Invalid category #{category}, "\
-        'to add a new category use #add_category' unless
-        categories.include? category
+      unless categories.include? category
+        raise ArgumentError, "Invalid category #{category}, "\
+          'to add a new category use #add_category'
+      end
       old_category = category_from_position pos
       @array[pos] = int_from_cat category
       @cat_hash[old_category].delete pos

--- a/lib/daru/dataframe.rb
+++ b/lib/daru/dataframe.rb
@@ -265,9 +265,11 @@ module Daru
       case lib
       when :gruff, :nyaplot
         @plotting_library = lib
-        extend Module.const_get(
-          "Daru::Plotting::DataFrame::#{lib.to_s.capitalize}Library"
-        ) if Daru.send("has_#{lib}?".to_sym)
+        if Daru.send("has_#{lib}?".to_sym)
+          extend Module.const_get(
+            "Daru::Plotting::DataFrame::#{lib.to_s.capitalize}Library"
+          )
+        end
       else
         raise ArguementError, "Plotting library #{lib} not supported. "\
           'Supported libraries are :nyaplot and :gruff'
@@ -1230,8 +1232,10 @@ module Daru
     end
 
     def reindex_vectors new_vectors
-      raise ArgumentError, 'Must pass the new index of type Index or its '\
-        "subclasses, not #{new_index.class}" unless new_vectors.is_a?(Daru::Index)
+      unless new_vectors.is_a?(Daru::Index)
+        raise ArgumentError, 'Must pass the new index of type Index or its '\
+          "subclasses, not #{new_index.class}"
+      end
 
       cl = Daru::DataFrame.new({}, order: new_vectors, index: @index, name: @name)
       new_vectors.each_with_object(cl) do |vec, memo|
@@ -1289,8 +1293,10 @@ module Daru
     #   #         a          1         11
     #   #         g        nil        nil
     def reindex new_index
-      raise ArgumentError, 'Must pass the new index of type Index or its '\
-        "subclasses, not #{new_index.class}" unless new_index.is_a?(Daru::Index)
+      unless new_index.is_a?(Daru::Index)
+        raise ArgumentError, 'Must pass the new index of type Index or its '\
+          "subclasses, not #{new_index.class}"
+      end
 
       cl = Daru::DataFrame.new({}, order: @vectors, index: new_index, name: @name)
       new_index.each_with_object(cl) do |idx, memo|
@@ -1327,10 +1333,14 @@ module Daru
     #   df.vectors = Daru::Index.new([:foo, :bar, :baz])
     #   df.vectors.to_a #=> [:foo, :bar, :baz]
     def vectors= idx
-      raise ArgumentError, 'Can only reindex with Index and its subclasses' unless
-        index.is_a?(Daru::Index)
-      raise ArgumentError, "Specified index length #{idx.size} not equal to"\
-        "dataframe size #{ncols}" if idx.size != ncols
+      unless index.is_a?(Daru::Index)
+        raise ArgumentError, 'Can only reindex with Index and its subclasses'
+      end
+
+      if idx.size != ncols
+        raise ArgumentError, "Specified index length #{idx.size} not equal to"\
+          "dataframe size #{ncols}"
+      end
 
       @vectors = idx
       self
@@ -1564,9 +1574,10 @@ module Daru
     #
     # @return {Daru::DataFrame}
     def merge other_df # rubocop:disable Metrics/AbcSize
-      raise ArgumentError,
-        "Number of rows must be equal in this: #{nrows} and other: #{other_df.nrows}" \
-        unless nrows == other_df.nrows
+      unless nrows == other_df.nrows
+        raise ArgumentError,
+          "Number of rows must be equal in this: #{nrows} and other: #{other_df.nrows}"
+      end
 
       new_fields = (@vectors.to_a + other_df.vectors.to_a)
       new_fields = ArrayHelper.recode_repeated(new_fields)
@@ -2158,9 +2169,10 @@ module Daru
         }
       else
         # FIXME: No spec checks this case... And SizeError is not a thing - zverok, 2016-05-08
-        raise SizeError,
-          "Specified vector of length #{vector.size} cannot be inserted in DataFrame of size #{@size}" if
-          @size != vector.size
+        if @size != vector.size
+          raise SizeError,
+            "Specified vector of length #{vector.size} cannot be inserted in DataFrame of size #{@size}"
+        end
 
         Daru::Vector.new(vector, name: coerce_name(name), index: @index)
       end
@@ -2187,12 +2199,13 @@ module Daru
     end
 
     def validate_labels
-      raise IndexError, "Expected equal number of vector names (#{@vectors.size}) " \
-        "for number of vectors (#{@data.size})." if
-        @vectors && @vectors.size != @data.size
+      if @vectors && @vectors.size != @data.size
+        raise IndexError, "Expected equal number of vector names (#{@vectors.size}) " \
+          "for number of vectors (#{@data.size})."
+      end
 
-      raise IndexError, 'Expected number of indexes same as number of rows' if
-        @index && @data[0] && @index.size != @data[0].size
+      return unless @index && @data[0] && @index.size != @data[0].size
+      raise IndexError, 'Expected number of indexes same as number of rows'
     end
 
     def validate_vector_sizes
@@ -2258,8 +2271,10 @@ module Daru
     end
 
     def initialize_from_array_of_arrays source, vectors, index, _opts
-      raise ArgumentError, "Number of vectors (#{vectors.size}) should " \
-        "equal order size (#{source.size})" if source.size != vectors.size
+      if source.size != vectors.size
+        raise ArgumentError, "Number of vectors (#{vectors.size}) should " \
+          "equal order size (#{source.size})"
+      end
 
       @index   = Index.coerce(index || source[0].size)
       @vectors = Index.coerce(vectors)

--- a/lib/daru/date_time/index.rb
+++ b/lib/daru/date_time/index.rb
@@ -87,8 +87,7 @@ module Daru
       def verify_start_and_end start, en
         raise ArgumentError, 'Start and end cannot be the same' if start == en
         raise ArgumentError, 'Start must be lesser than end'    if start > en
-        raise ArgumentError,
-          'Only same time zones are allowed' if start.zone != en.zone
+        raise ArgumentError, 'Only same time zones are allowed' if start.zone != en.zone
       end
 
       def infer_offset data

--- a/lib/daru/index/multi_index.rb
+++ b/lib/daru/index/multi_index.rb
@@ -17,12 +17,10 @@ module Daru
     def initialize opts={}
       labels = opts[:labels]
       levels = opts[:levels]
-      raise ArgumentError,
-        'Must specify both labels and levels' unless labels && levels
-      raise ArgumentError,
-        'Labels and levels should be same size' if labels.size != levels.size
-      raise ArgumentError,
-        'Incorrect labels and levels' if incorrect_fields?(labels, levels)
+
+      raise ArgumentError, 'Must specify both labels and levels' unless labels && levels
+      raise ArgumentError, 'Labels and levels should be same size' if labels.size != levels.size
+      raise ArgumentError, 'Incorrect labels and levels' if incorrect_fields?(labels, levels)
 
       @labels = labels
       @levels = levels.map { |e| e.map.with_index.to_h }
@@ -177,8 +175,7 @@ module Daru
       :retrieve_from_range, :retrieve_from_tuples
 
     def key index
-      raise ArgumentError,
-        "Key #{index} is too large" if index >= @labels[0].size
+      raise ArgumentError, "Key #{index} is too large" if index >= @labels[0].size
 
       @labels
         .each_with_index

--- a/lib/daru/plotting/gruff/dataframe.rb
+++ b/lib/daru/plotting/gruff/dataframe.rb
@@ -7,9 +7,9 @@ module Daru
           size = opts[:size] || 500
           x = extract_x_vector opts[:x]
           y = extract_y_vectors opts[:y]
-          return plot_with_category(
-            size, type, x, y, opts[:categorized]
-          ) if opts[:categorized]
+          if opts[:categorized]
+            return plot_with_category(size, type, x, y, opts[:categorized])
+          end
           case type
           when :line, :bar, :scatter
             plot = send("#{type}_plot", size, x, y)

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -190,9 +190,11 @@ module Daru
       case lib
       when :gruff, :nyaplot
         @plotting_library = lib
-        extend Module.const_get(
-          "Daru::Plotting::Vector::#{lib.to_s.capitalize}Library"
-        ) if Daru.send("has_#{lib}?".to_sym)
+        if Daru.send("has_#{lib}?".to_sym)
+          extend Module.const_get(
+            "Daru::Plotting::Vector::#{lib.to_s.capitalize}Library"
+          )
+        end
       else
         raise ArguementError, "Plotting library #{lib} not supported. "\
           'Supported libraries are :nyaplot and :gruff'
@@ -825,8 +827,10 @@ module Daru
     #   # [
     #   #   [1, 2, 3] ]
     def to_nmatrix axis=:horizontal
-      raise ArgumentError, 'Can not convert to nmatrix'\
-        'because the vector is numeric' unless numeric? && !include?(nil)
+      unless numeric? && !include?(nil)
+        raise ArgumentError, 'Can not convert to nmatrix'\
+          'because the vector is numeric'
+      end
 
       case axis
       when :horizontal
@@ -984,11 +988,14 @@ module Daru
     def index= idx
       idx = Index.coerce idx
 
-      raise ArgumentError,
-        "Size of supplied index #{idx.size} does not match size of Vector" if
-        idx.size != size
-      raise ArgumentError, 'Can only assign type Index and its subclasses.' unless
-        idx.is_a?(Daru::Index)
+      if idx.size != size
+        raise ArgumentError,
+          "Size of supplied index #{idx.size} does not match size of Vector"
+      end
+
+      unless idx.is_a?(Daru::Index)
+        raise ArgumentError, 'Can only assign type Index and its subclasses.'
+      end
 
       @index = idx
       self

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -964,7 +964,8 @@ module Daru
     #   #   c   3
     def reorder! order
       @index = @index.reorder order
-      @data = Accessors::ArrayWrapper.new(order.map { |i| @data[i] }, self)
+      data_array = order.map { |i| @data[i] }
+      @data = cast_vector_to @dtype, data_array, @nm_dtype
       update_position_cache
       self
     end

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -964,7 +964,7 @@ module Daru
     #   #   c   3
     def reorder! order
       @index = @index.reorder order
-      @data = order.map { |i| @data[i] }
+      @data = Accessors::ArrayWrapper.new(order.map { |i| @data[i] }, self)
       update_position_cache
       self
     end

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -86,6 +86,30 @@ describe Daru::Vector do
 
       end
 
+      context "#reorder!" do
+        let(:vector_with_dtype) do
+          Daru::Vector.new(
+            [1, 2, 3, 4],
+            index: [:a, :b, :c, :d],
+            dtype: dtype)
+        end
+        let(:arranged_vector) do
+          Daru::Vector.new([4,3,2,1], index: [:d, :c, :b, :a], dtype: dtype)
+        end
+
+        before do
+          vector_with_dtype.reorder! [3, 2, 1, 0]
+        end
+
+        it "rearranges with passed order" do
+          expect(vector_with_dtype).to eq arranged_vector
+        end
+
+        it "doesn't change dtype" do
+          expect(vector_with_dtype.data.class).to eq arranged_vector.data.class
+        end
+      end
+
       context ".new_with_size" do
         it "creates new vector from only size" do
           v1 = Daru::Vector.new 10.times.map { nil }, dtype: dtype


### PR DESCRIPTION
`Vector#reorder!` method overrode `@data` with `Array`. 
`@data` must be instance of `Accessors::ArrayWrapper`.

Same for #276 , only branch name differs.
