### PR TITLE
Comparison Operator for Daru::Vector

### DIFF
--- a/daru.gemspec
+++ b/daru.gemspec
@@ -73,8 +73,12 @@ EOF
   spec.add_development_dependency 'rubocop', '>= 0.40.0'
   spec.add_development_dependency 'ruby-prof'
   spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'nokogiri'
   spec.add_development_dependency 'gruff'
+  if RUBY_VERSION < '2.1.0'
+    spec.add_development_dependency 'nokogiri', '<= 1.6.8.1'
+  else
+    spec.add_development_dependency 'nokogiri'
+  end
   if RUBY_VERSION >= '2.2.5'
     spec.add_development_dependency 'guard-rspec'
   end

--- a/lib/daru/vector.rb
+++ b/lib/daru/vector.rb
@@ -353,6 +353,7 @@ module Daru
           mod.apply_scalar_operator operator, @data,other
         end
       end
+      alias_method operator, method if operator != :== && operator != :!=
     end
     alias :gt :mt
     alias :gteq :mteq


### PR DESCRIPTION
For https://github.com/v0dro/daru/issues/287 .

I didn't create method-alias for `==` and `!=`, because they conflict with `==` and `!=` that check equivalence of two vectors.